### PR TITLE
Added new map mode: heatmap

### DIFF
--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -1,16 +1,43 @@
-﻿namespace ProspectorInfo.Map
+﻿using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using Vintagestory.API.Common;
+using Vintagestory.API.Config;
+using Vintagestory.API.Datastructures;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+using Vintagestory.GameContent;
+using Vintagestory.ServerMods;
+
+namespace ProspectorInfo.Map
 {
     internal class ProspectInfo
     {
         public readonly int X;
         public readonly int Z;
-        public string Message;
+        public readonly List<OreOccurence> Values;
+        [Newtonsoft.Json.JsonIgnore]
+        private readonly string Message; //Used for backwards compatibility
 
-        public ProspectInfo(int x, int z, string message)
+        private readonly Regex _cleanupRegex = new Regex("<.*?>", RegexOptions.Compiled);
+
+        [Newtonsoft.Json.JsonConstructor]
+        public ProspectInfo(int x, int z, string message, List<OreOccurence> values)
         {
             X = x;
             Z = z;
             Message = message;
+            Values = values;
+            if (values == null)
+                Values = new List<OreOccurence>();
+        }
+
+        public ProspectInfo(BlockPos pos, int chunkSize, ICoreServerAPI api, ProPickWorkSpace ppws)
+        {
+            X = pos.X / chunkSize;
+            Z = pos.Z / chunkSize;
+            Values = new List<OreOccurence>();
+            GetDepositValues(pos, api, ppws);
         }
 
         public bool Equals(ProspectInfo other)
@@ -30,6 +57,123 @@
                 return (X * 397) ^ Z;
             }
         }
+
+        public string GetMessage()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            if (Values.Count > 0)
+            {
+                sb.AppendLine(Lang.Get("propick-reading-title", Values.Count));
+
+                string[] densityStrings = new string[] { "propick-density-verypoor", "propick-density-poor", "propick-density-decent", "propick-density-high", "propick-density-veryhigh", "propick-density-ultrahigh" };
+                var sbTrace = new StringBuilder();
+                int traceCount = 0;
+
+                foreach (var elem in Values)
+                {
+                    if (elem.relativeDensity > RelativeDensity.Miniscule)
+                    {
+                        string proPickReading = Lang.Get("propick-reading", Lang.Get(densityStrings[(int)elem.relativeDensity - 2]), "ore", Lang.Get("ore-" + elem.name), elem.absoluteDensity.ToString("0.#"));
+                        proPickReading = _cleanupRegex.Replace(proPickReading, string.Empty);
+                        sb.AppendLine(proPickReading);
+                    }
+                    else
+                    {
+                        if (traceCount > 0)
+                            sbTrace.Append(", ");
+                        sbTrace.Append(Lang.Get("ore-" + elem.name));
+                        traceCount++;
+                    }
+                }
+                sb.Append(Lang.Get("Miniscule amounts of {0}", sbTrace.ToString()));
+                sb.AppendLine();
+            }
+            else
+            {
+                if (Message != null)
+                    sb.Append(Message);
+                else
+                    sb.Append(Lang.Get("propick-noreading"));
+            }
+            return sb.ToString();
+        }
+
+        public RelativeDensity GetValueOfOre(string oreName)
+        {
+            foreach (var ore in Values)
+            {
+                if (Lang.Get("ore-" + ore.name).ToLower() == oreName.ToLower() || ore.name.ToLower() == oreName.ToLower())
+                    return ore.relativeDensity;
+            }
+            return RelativeDensity.Zero;
+        }
+
+        private void GetDepositValues(BlockPos pos, ICoreServerAPI api, ProPickWorkSpace ppws)
+        {
+            DepositVariant[] deposits = api.ModLoader.GetModSystem<GenDeposits>()?.Deposits;
+            if (deposits == null) return;
+
+            IBlockAccessor blockAccess = api.World.BlockAccessor;
+            int regsize = blockAccess.RegionSize;
+
+            IMapRegion reg = api.World.BlockAccessor.GetMapRegion(pos.X / regsize, pos.Z / regsize);
+            int lx = pos.X % regsize;
+            int lz = pos.Z % regsize;
+
+            pos = pos.Copy();
+            pos.Y = api.World.BlockAccessor.GetTerrainMapheightAt(pos);
+
+            int[] blockColumn = ppws.GetRockColumn(pos.X, pos.Z);
+
+            foreach (var val in reg.OreMaps)
+            {
+                IntDataMap2D map = val.Value;
+                int noiseSize = map.InnerSize;
+
+                float posXInRegionOre = (float)lx / regsize * noiseSize;
+                float posZInRegionOre = (float)lz / regsize * noiseSize;
+
+                int oreDist = map.GetUnpaddedColorLerped(posXInRegionOre, posZInRegionOre);
+
+                ppws.depositsByCode[val.Key].GetPropickReading(pos, oreDist, blockColumn, out double ppt, out double totalFactor);
+
+                if (totalFactor > 0.025)
+                {
+                    Values.Add(new OreOccurence(val.Key, (RelativeDensity)((int)GameMath.Clamp(totalFactor * 7.5f, 0, 5) + 2), ppt));
+                }
+                else if (totalFactor > 0.002)
+                {
+                    Values.Add(new OreOccurence(val.Key, RelativeDensity.Miniscule, totalFactor));
+                }
+            }
+            Values.Sort(delegate (OreOccurence it, OreOccurence other) { return other.relativeDensity - it.relativeDensity; });
+        }
     }
 
+    internal struct OreOccurence
+    {
+        public string name;
+        public RelativeDensity relativeDensity;
+        public double absoluteDensity;
+
+        public OreOccurence(string name, RelativeDensity relativeDensity, double absoluteDensity)
+        {
+            this.name = name;
+            this.relativeDensity = relativeDensity;
+            this.absoluteDensity = absoluteDensity;
+        }
+    }
+
+    internal enum RelativeDensity
+    {
+        Zero,
+        Miniscule,
+        VeryPoor,
+        Poor,
+        Decent,
+        High,
+        VeryHigh,
+        UltraHigh
+    }
 }

--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -1,16 +1,21 @@
-﻿namespace ProspectorInfo.Map
+﻿using System.Collections.Generic;
+
+namespace ProspectorInfo.Map
 {
     internal class ProspectInfo
     {
         public readonly int X;
         public readonly int Z;
         public string Message;
+        public List<OreOccurence> Values;
 
         public ProspectInfo(int x, int z, string message)
         {
             X = x;
             Z = z;
             Message = message;
+            Values = new List<OreOccurence>();
+            ParseMessage();
         }
 
         public bool Equals(ProspectInfo other)
@@ -30,6 +35,111 @@
                 return (X * 397) ^ Z;
             }
         }
+
+        /// <summary>
+        /// Parses Message into a list of OreOccurence. Works only for English. 
+        /// //TODO find a way to get the data multi lingual
+        /// </summary>
+        public void ParseMessage()
+        {
+            string[] seperator = { "\r\n" };
+            string[] split = Message.Split(seperator, System.StringSplitOptions.RemoveEmptyEntries);
+            string[] keySeperator = { ", ", " (", "‰" };
+            for (int i = 1; i < split.Length; i++)
+            {
+                if (split[i].StartsWith("Miniscule"))
+                {
+                    string[] keys = split[i].Substring(21).Split(keySeperator, System.StringSplitOptions.RemoveEmptyEntries);
+                    foreach (var key in keys)
+                    {
+                        Values.Add(new OreOccurence(key, RelativeDensity.Miniscule, 0));
+                    }
+                }
+                else if (split[i].StartsWith("Very poor"))
+                {
+                    string[] key = split[i].Substring(10).Split(keySeperator, System.StringSplitOptions.RemoveEmptyEntries);
+                    if (!System.Single.TryParse(key[1].Replace(',', '.'), out float absolute))
+                        absolute = -1;
+
+                    Values.Add(new OreOccurence(key[0], RelativeDensity.VeryPoor, absolute));
+                }
+                else if (split[i].StartsWith("Poor"))
+                {
+                    string[] key = split[i].Substring(5).Split(keySeperator, System.StringSplitOptions.RemoveEmptyEntries);
+                    if (!System.Single.TryParse(key[1].Replace(',', '.'), out float absolute))
+                        absolute = -1;
+
+                    Values.Add(new OreOccurence(key[0], RelativeDensity.Poor, absolute));
+                }
+                else if (split[i].StartsWith("Decent"))
+                {
+                    string[] key = split[i].Substring(7).Split(keySeperator, System.StringSplitOptions.RemoveEmptyEntries);
+                    if (!System.Single.TryParse(key[1].Replace(',', '.'), out float absolute))
+                        absolute = -1;
+
+                    Values.Add(new OreOccurence(key[0], RelativeDensity.Decent, absolute));
+                }
+                else if (split[i].StartsWith("High"))
+                {
+                    string[] key = split[i].Substring(5).Split(keySeperator, System.StringSplitOptions.RemoveEmptyEntries);
+                    if (!System.Single.TryParse(key[1].Replace(',', '.'), out float absolute))
+                        absolute = -1;
+
+                    Values.Add(new OreOccurence(key[0], RelativeDensity.High, absolute));
+                }
+                else if (split[i].StartsWith("Very high"))
+                {
+                    string[] key = split[i].Substring(10).Split(keySeperator, System.StringSplitOptions.RemoveEmptyEntries);
+                    if (!System.Single.TryParse(key[1].Replace(',', '.'), out float absolute))
+                        absolute = -1;
+
+                    Values.Add(new OreOccurence(key[0], RelativeDensity.VeryHigh, absolute));
+                }
+                else if (split[i].StartsWith("Ultra high"))
+                {
+                    string[] key = split[i].Substring(11).Split(keySeperator, System.StringSplitOptions.RemoveEmptyEntries);
+                    if (!System.Single.TryParse(key[1].Replace(',', '.'), out float absolute))
+                        absolute = -1;
+
+                    Values.Add(new OreOccurence(key[0], RelativeDensity.UltraHigh, absolute));
+                }
+            }
+        }
+
+        public RelativeDensity GetValueOfOre(string oreName)
+        {
+            foreach (var ore in Values)
+            {
+                if (ore.name == oreName)
+                    return ore.relativeDensity;
+            }
+            return RelativeDensity.Zero;
+        }
     }
 
+    internal struct OreOccurence
+    {
+        public string name;
+        public RelativeDensity relativeDensity;
+        public float absoluteDensity;
+
+        public OreOccurence(string name, RelativeDensity relativeDensity, float absoluteDensity)
+        {
+            this.name = name;
+            this.relativeDensity = relativeDensity;
+            this.absoluteDensity = absoluteDensity;
+        }
+    }
+
+    internal enum RelativeDensity
+    {
+        Zero,
+        Miniscule,
+        VeryPoor,
+        Poor,
+        Decent,
+        High,
+        VeryHigh,
+        UltraHigh
+    }
 }

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -162,42 +162,6 @@ namespace ProspectorInfo.Map
                         _clientApi.ShowChatMessage(e.Message);
                     }
                     break;
-                case "setlowheatcolor":
-                    try
-                    {
-                        var newColor = TrySetRGBAValues(args, _config.BorderColor);
-                        _config.LowHeatColor = newColor;
-                        _config.Save(api);
-
-                        RebuildMap(true);
-                    }
-                    catch (FormatException e)
-                    {
-                        _clientApi.ShowChatMessage(e.Message);
-                    }
-                    catch (ArgumentException e)
-                    {
-                        _clientApi.ShowChatMessage(e.Message);
-                    }
-                    break;
-                case "sethighheatcolor":
-                    try
-                    {
-                        var newColor = TrySetRGBAValues(args, _config.BorderColor);
-                        _config.HighHeatColor = newColor;
-                        _config.Save(api);
-
-                        RebuildMap(true);
-                    }
-                    catch (FormatException e)
-                    {
-                        _clientApi.ShowChatMessage(e.Message);
-                    }
-                    catch (ArgumentException e)
-                    {
-                        _clientApi.ShowChatMessage(e.Message);
-                    }
-                    break;
                 case "setborderthickness":
                     var newThickness = args.PopInt(2).Value;
                     _config.BorderThickness = newThickness;

--- a/src/ModConfig.cs
+++ b/src/ModConfig.cs
@@ -9,9 +9,13 @@ namespace ProspectorInfo
 
         public bool RenderTexturesOnMap { get; set; } = false;
         public ColorWithAlpha TextureColor { get; set; } = new ColorWithAlpha(150, 125, 150, 128);
+        public ColorWithAlpha LowHeatColor { get; set; } = new ColorWithAlpha(85, 85, 181, 128);
+        public ColorWithAlpha HighHeatColor { get; set; } = new ColorWithAlpha(168, 34, 36, 128);
         public ColorWithAlpha BorderColor { get; set; } = new ColorWithAlpha(0, 0, 0, 200);
         public int BorderThickness { get; set; } = 1;
         public bool RenderBorder { get; set; } = true;
         public bool AutoToggle { get; set; } = true;
+        public int MapMode { get; set; } = 0;
+        public string HeatMapOre { get; set; } = null;
     }
 }


### PR DESCRIPTION
Adds a new map mode that displays the relative density of the ores on the map via a color gradient. Can be enabled/disabled and switched between displaying the density of just one ore and displaying the density of all ores (The highest density per chunk is picked).

Normal map (map mode 0)
![map](https://user-images.githubusercontent.com/24532072/168427928-96b134aa-288d-4d4c-ade6-ddcb002c6d51.png)
Heatmap (map mode 1)
![heatmap](https://user-images.githubusercontent.com/24532072/168427930-571788d3-eca5-4cbb-b6d6-caf2c6b9bcd1.png)
Heatmap for Cassiterite only (map mode 1; heatmapore Cassiterite)
![heatmapCassiterite](https://user-images.githubusercontent.com/24532072/168427932-9fd7020f-3248-4708-8f68-25a082a86bd2.png)

Draft because it's currently only working for English because I didn't find a way to fetch the data from the VSApi directly.
Also breaks the compatibility to the [VSOneshotPropickMod](https://github.com/Spoonail-Iroiro/VSOneshotPropickMod) for me but don't know why... Do you have any idea why the compatibility could break?