### PR TITLE
Added a settings GUI to the map (contains PR #4)

### DIFF
--- a/src/Map/GuiProspectorInfoSettings.cs
+++ b/src/Map/GuiProspectorInfoSettings.cs
@@ -19,7 +19,8 @@ namespace ProspectorInfo.Map
             _rebuildMap = rebuildMap;
 
             IDictionary<string, string> oreValues = Vintagestory.API.Config.Lang.GetAllEntries();
-            oreValues.RemoveAll((key, val) => !key.Contains(":ore-") || key.CountChars('-') != 1);
+            // game:ore-lapis is a leftover and unused so it can be removed. See https://discord.com/channels/302152934249070593/351624415039193098/1009372460568805427
+            oreValues.RemoveAll((key, val) => !key.Contains(":ore-") || key.CountChars('-') != 1 || key.Contains("_") || key == "game:ore-lapis");
             _ores = oreValues.OrderBy((pair) => pair.Value).ToList();
             _ores.Insert(0, new KeyValuePair<string, string>(null, "All ores"));
 
@@ -40,9 +41,13 @@ namespace ProspectorInfo.Map
             ElementBounds mapModeBounds = ElementBounds.Fixed(35, 100, 120, 20);
             ElementBounds oreBounds = ElementBounds.Fixed(35, 130, 120, 20);
 
-            var currentHeatmapOreIndex = _ores.FindIndex((pair) => pair.Key != null && pair.Key.Contains(_config.HeatMapOre));
-            if (currentHeatmapOreIndex == -1)
-                currentHeatmapOreIndex = 0;
+            var currentHeatmapOreIndex = 0;
+            if (_config.HeatMapOre != null)
+            {
+                currentHeatmapOreIndex = _ores.FindIndex((pair) => pair.Key != null && pair.Key.Contains(_config.HeatMapOre));
+                if (currentHeatmapOreIndex == -1) // config.HeatMapOre is not a valid ore name -> reset to all ores
+                    currentHeatmapOreIndex = 0;
+            }
 
             SingleComposer = capi.Gui.CreateCompo("ProspectorInfo Settings", dialogBounds)
                 .AddShadedDialogBG(backgroundBounds)

--- a/src/Map/GuiProspectorInfoSettings.cs
+++ b/src/Map/GuiProspectorInfoSettings.cs
@@ -11,7 +11,7 @@ namespace ProspectorInfo.Map
         public override string ToggleKeyCombinationCode => "prospectorinfosettings";
         private readonly ModConfig _config;
         private readonly Action<bool> _rebuildMap;
-        private readonly IOrderedEnumerable<KeyValuePair<string, string>> _ores;
+        private readonly List<KeyValuePair<string, string>> _ores;
 
         public GuiProspectorInfoSetting(ICoreClientAPI capi, ModConfig config, Action<bool> rebuildMap) : base(capi)
         {
@@ -20,7 +20,8 @@ namespace ProspectorInfo.Map
 
             IDictionary<string, string> oreValues = Vintagestory.API.Config.Lang.GetAllEntries();
             oreValues.RemoveAll((key, val) => !key.Contains(":ore-") || key.CountChars('-') != 1);
-            _ores = oreValues.OrderBy((pair) => pair.Value);
+            _ores = oreValues.OrderBy((pair) => pair.Value).ToList();
+            _ores.Insert(0, new KeyValuePair<string, string>(null, "All ores"));
 
             SetupDialog();
         }
@@ -39,13 +40,17 @@ namespace ProspectorInfo.Map
             ElementBounds mapModeBounds = ElementBounds.Fixed(35, 100, 120, 20);
             ElementBounds oreBounds = ElementBounds.Fixed(35, 130, 120, 20);
 
+            var currentHeatmapOreIndex = _ores.FindIndex((pair) => pair.Key != null && pair.Key.Contains(_config.HeatMapOre));
+            if (currentHeatmapOreIndex == -1)
+                currentHeatmapOreIndex = 0;
+
             SingleComposer = capi.Gui.CreateCompo("ProspectorInfo Settings", dialogBounds)
                 .AddShadedDialogBG(backgroundBounds)
                 .AddDialogTitleBar("ProspectorInfo", OnCloseTitleBar)
                 .AddStaticText("Show overlay", CairoFont.WhiteDetailText(), showOverlayTextBounds)
                 .AddSwitch(OnSwitchOverlay, switchBounds, "showOverlaySwitch")
                 .AddDropDown(new string[] { "0", "1" }, new string[] { "Default", "Heatmap" }, _config.MapMode, OnMapModeSelected, mapModeBounds)
-                .AddDropDown(_ores.Select((pair) => pair.Key).ToArray(), _ores.Select((pair) => pair.Value).ToArray(), _config.MapMode, OnHeatmapOreSelected, oreBounds)
+                .AddDropDown(_ores.Select((pair) => pair.Key).ToArray(), _ores.Select((pair) => pair.Value).ToArray(), currentHeatmapOreIndex, OnHeatmapOreSelected, oreBounds)
                 .Compose();
 
             SingleComposer.GetSwitch("showOverlaySwitch").On = _config.RenderTexturesOnMap;
@@ -75,7 +80,7 @@ namespace ProspectorInfo.Map
         private void OnHeatmapOreSelected(string code, bool selected)
         {
             // We can assume that only one dash exists in "code" since this a search criteria in the constructor 
-            _config.HeatMapOre = code.Split('-').Last();
+            _config.HeatMapOre = code?.Split('-').Last(); 
             _config.Save(capi);
             _rebuildMap(true);
         }

--- a/src/Map/GuiProspectorInfoSettings.cs
+++ b/src/Map/GuiProspectorInfoSettings.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vintagestory.API.Client;
+using Vintagestory.API.Util;
+
+namespace ProspectorInfo.Map
+{
+    public class GuiProspectorInfoSetting : GuiDialog
+    {
+        public override string ToggleKeyCombinationCode => "prospectorinfosettings";
+        private readonly ModConfig _config;
+        private readonly Action<bool> _rebuildMap;
+        private readonly IOrderedEnumerable<KeyValuePair<string, string>> _ores;
+
+        public GuiProspectorInfoSetting(ICoreClientAPI capi, ModConfig config, Action<bool> rebuildMap) : base(capi)
+        {
+            _config = config;
+            _rebuildMap = rebuildMap;
+
+            IDictionary<string, string> oreValues = Vintagestory.API.Config.Lang.GetAllEntries();
+            oreValues.RemoveAll((key, val) => !key.Contains(":ore-") || key.CountChars('-') != 1);
+            _ores = oreValues.OrderBy((pair) => pair.Value);
+
+            SetupDialog();
+        }
+
+        private void SetupDialog()
+        {
+            // Auto-sized dialog at the center of the screen
+            ElementBounds dialogBounds = ElementStdBounds.AutosizedMainDialog.WithAlignment(EnumDialogArea.RightMiddle);
+            ElementBounds backgroundBounds = ElementBounds.Fill.WithFixedPadding(GuiStyle.ElementToDialogPadding);
+            ElementBounds dialogContainerBounds = ElementBounds.Fixed(0, 40, 150, 150);
+            backgroundBounds.BothSizing = ElementSizing.FitToChildren;
+            backgroundBounds.WithChildren(dialogContainerBounds);
+
+            ElementBounds showOverlayTextBounds = ElementBounds.Fixed(35, 50);
+            ElementBounds switchBounds = ElementBounds.Fixed(125, 50);
+            ElementBounds mapModeBounds = ElementBounds.Fixed(35, 100, 120, 20);
+            ElementBounds oreBounds = ElementBounds.Fixed(35, 130, 120, 20);
+
+            SingleComposer = capi.Gui.CreateCompo("ProspectorInfo Settings", dialogBounds)
+                .AddShadedDialogBG(backgroundBounds)
+                .AddDialogTitleBar("ProspectorInfo", OnCloseTitleBar)
+                .AddStaticText("Show overlay", CairoFont.WhiteDetailText(), showOverlayTextBounds)
+                .AddSwitch(OnSwitchOverlay, switchBounds, "showOverlaySwitch")
+                .AddDropDown(new string[] { "0", "1" }, new string[] { "Default", "Heatmap" }, _config.MapMode, OnMapModeSelected, mapModeBounds)
+                .AddDropDown(_ores.Select((pair) => pair.Key).ToArray(), _ores.Select((pair) => pair.Value).ToArray(), _config.MapMode, OnHeatmapOreSelected, oreBounds)
+                .Compose();
+
+            SingleComposer.GetSwitch("showOverlaySwitch").On = _config.RenderTexturesOnMap;
+        }
+
+        private void OnCloseTitleBar()
+        {
+            _config.ShowGui = false;
+            _config.Save(capi);
+            TryClose();
+        }
+
+        private void OnSwitchOverlay(bool value)
+        {
+            _config.RenderTexturesOnMap = value;
+            _config.Save(capi);
+            _rebuildMap(true);
+        }
+
+        private void OnMapModeSelected(string code, bool selected)
+        {
+            _config.MapMode = int.Parse(code);
+            _config.Save(capi);
+            _rebuildMap(true);
+        }
+
+        private void OnHeatmapOreSelected(string code, bool selected)
+        {
+            // We can assume that only one dash exists in "code" since this a search criteria in the constructor 
+            _config.HeatMapOre = code.Split('-').Last();
+            _config.Save(capi);
+            _rebuildMap(true);
+        }
+    }
+}

--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -16,7 +16,6 @@ namespace ProspectorInfo.Map
         public readonly int X;
         public readonly int Z;
         public readonly List<OreOccurence> Values;
-        [Newtonsoft.Json.JsonIgnore]
         private readonly string Message; //Used for backwards compatibility
 
         private readonly Regex _cleanupRegex = new Regex("<.*?>", RegexOptions.Compiled);

--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -1,16 +1,43 @@
-﻿namespace ProspectorInfo.Map
+﻿using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using Vintagestory.API.Common;
+using Vintagestory.API.Config;
+using Vintagestory.API.Datastructures;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+using Vintagestory.GameContent;
+using Vintagestory.ServerMods;
+
+namespace ProspectorInfo.Map
 {
     internal class ProspectInfo
     {
         public readonly int X;
         public readonly int Z;
-        public string Message;
+        public readonly List<OreOccurence> Values;
+        [Newtonsoft.Json.JsonIgnore]
+        private readonly string Message; //Used for backwards compatibility
 
-        public ProspectInfo(int x, int z, string message)
+        private readonly Regex _cleanupRegex = new Regex("<.*?>", RegexOptions.Compiled);
+
+        [Newtonsoft.Json.JsonConstructor]
+        public ProspectInfo(int x, int z, string message, List<OreOccurence> values)
         {
             X = x;
             Z = z;
             Message = message;
+            Values = values;
+            if (values == null)
+                Values = new List<OreOccurence>();
+        }
+
+        public ProspectInfo(BlockPos pos, int chunkSize, ICoreServerAPI api, ProPickWorkSpace ppws)
+        {
+            X = pos.X / chunkSize;
+            Z = pos.Z / chunkSize;
+            Values = new List<OreOccurence>();
+            GetDepositValues(pos, api, ppws);
         }
 
         public bool Equals(ProspectInfo other)
@@ -30,6 +57,123 @@
                 return (X * 397) ^ Z;
             }
         }
+
+        public string GetMessage()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            if (Values.Count > 0)
+            {
+                sb.AppendLine(Lang.Get("propick-reading-title", Values.Count));
+
+                string[] densityStrings = new string[] { "propick-density-verypoor", "propick-density-poor", "propick-density-decent", "propick-density-high", "propick-density-veryhigh", "propick-density-ultrahigh" };
+                var sbTrace = new StringBuilder();
+                int traceCount = 0;
+
+                foreach (var elem in Values)
+                {
+                    if (elem.relativeDensity > RelativeDensity.Miniscule)
+                    {
+                        string proPickReading = Lang.Get("propick-reading", Lang.Get(densityStrings[(int)elem.relativeDensity - 2]), "ore", Lang.Get("ore-" + elem.name), elem.absoluteDensity.ToString("0.#"));
+                        proPickReading = _cleanupRegex.Replace(proPickReading, string.Empty);
+                        sb.AppendLine(proPickReading);
+                    }
+                    else
+                    {
+                        if (traceCount > 0)
+                            sbTrace.Append(", ");
+                        sbTrace.Append(Lang.Get("ore-" + elem.name));
+                        traceCount++;
+                    }
+                }
+                sb.Append(Lang.Get("Miniscule amounts of {0}", sbTrace.ToString()));
+                sb.AppendLine();
+            }
+            else
+            {
+                if (Message != null)
+                    sb.Append(Message);
+                else
+                    sb.Append(Lang.Get("propick-noreading"));
+            }
+            return sb.ToString();
+        }
+
+        public RelativeDensity GetValueOfOre(string oreName)
+        {
+            foreach (var ore in Values)
+            {
+                if (Lang.Get("ore-" + ore.name).ToLower() == oreName.ToLower() || ore.name.ToLower() == oreName.ToLower())
+                    return ore.relativeDensity;
+            }
+            return RelativeDensity.Zero;
+        }
+
+        private void GetDepositValues(BlockPos pos, ICoreServerAPI api, ProPickWorkSpace ppws)
+        {
+            DepositVariant[] deposits = api.ModLoader.GetModSystem<GenDeposits>()?.Deposits;
+            if (deposits == null) return;
+
+            IBlockAccessor blockAccess = api.World.BlockAccessor;
+            int regsize = blockAccess.RegionSize;
+
+            IMapRegion reg = api.World.BlockAccessor.GetMapRegion(pos.X / regsize, pos.Z / regsize);
+            int lx = pos.X % regsize;
+            int lz = pos.Z % regsize;
+
+            pos = pos.Copy();
+            pos.Y = api.World.BlockAccessor.GetTerrainMapheightAt(pos);
+
+            int[] blockColumn = ppws.GetRockColumn(pos.X, pos.Z);
+
+            foreach (var val in reg.OreMaps)
+            {
+                IntDataMap2D map = val.Value;
+                int noiseSize = map.InnerSize;
+
+                float posXInRegionOre = (float)lx / regsize * noiseSize;
+                float posZInRegionOre = (float)lz / regsize * noiseSize;
+
+                int oreDist = map.GetUnpaddedColorLerped(posXInRegionOre, posZInRegionOre);
+
+                ppws.depositsByCode[val.Key].GetPropickReading(pos, oreDist, blockColumn, out double ppt, out double totalFactor);
+
+                if (totalFactor > 0.025)
+                {
+                    Values.Add(new OreOccurence(val.Key, (RelativeDensity)((int)GameMath.Clamp(totalFactor * 7.5f, 0, 5) + 2), ppt));
+                }
+                else if (totalFactor > 0.002)
+                {
+                    Values.Add(new OreOccurence(val.Key, RelativeDensity.Miniscule, totalFactor));
+                }
+            }
+            Values.Sort(delegate (OreOccurence it, OreOccurence other) { return other.relativeDensity - it.relativeDensity; });
+        }
     }
 
+    internal struct OreOccurence
+    {
+        public string name;
+        public RelativeDensity relativeDensity;
+        public double absoluteDensity;
+
+        public OreOccurence(string name, RelativeDensity relativeDensity, double absoluteDensity)
+        {
+            this.name = name;
+            this.relativeDensity = relativeDensity;
+            this.absoluteDensity = absoluteDensity;
+        }
+    }
+
+    internal enum RelativeDensity
+    {
+        Zero,
+        Miniscule,
+        VeryPoor,
+        Poor,
+        Decent,
+        High,
+        VeryHigh,
+        UltraHigh
+    }
 }

--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -1,16 +1,21 @@
-﻿namespace ProspectorInfo.Map
+﻿using System.Collections.Generic;
+
+namespace ProspectorInfo.Map
 {
     internal class ProspectInfo
     {
         public readonly int X;
         public readonly int Z;
         public string Message;
+        public List<OreOccurence> Values;
 
         public ProspectInfo(int x, int z, string message)
         {
             X = x;
             Z = z;
             Message = message;
+            Values = new List<OreOccurence>();
+            ParseMessage();
         }
 
         public bool Equals(ProspectInfo other)
@@ -30,6 +35,111 @@
                 return (X * 397) ^ Z;
             }
         }
+
+        /// <summary>
+        /// Parses Message into a list of OreOccurence. Works only for English. 
+        /// //TODO find a way to get the data multi lingual
+        /// </summary>
+        public void ParseMessage()
+        {
+            string[] seperator = { "\r\n" };
+            string[] split = Message.Split(seperator, System.StringSplitOptions.RemoveEmptyEntries);
+            string[] keySeperator = { ", ", " (", "‰" };
+            for (int i = 1; i < split.Length; i++)
+            {
+                if (split[i].StartsWith("Miniscule"))
+                {
+                    string[] keys = split[i].Substring(21).Split(keySeperator, System.StringSplitOptions.RemoveEmptyEntries);
+                    foreach (var key in keys)
+                    {
+                        Values.Add(new OreOccurence(key, RelativeDensity.Miniscule, 0));
+                    }
+                }
+                else if (split[i].StartsWith("Very poor"))
+                {
+                    string[] key = split[i].Substring(10).Split(keySeperator, System.StringSplitOptions.RemoveEmptyEntries);
+                    if (!System.Single.TryParse(key[1].Replace(',', '.'), out float absolute))
+                        absolute = -1;
+
+                    Values.Add(new OreOccurence(key[0], RelativeDensity.VeryPoor, absolute));
+                }
+                else if (split[i].StartsWith("Poor"))
+                {
+                    string[] key = split[i].Substring(5).Split(keySeperator, System.StringSplitOptions.RemoveEmptyEntries);
+                    if (!System.Single.TryParse(key[1].Replace(',', '.'), out float absolute))
+                        absolute = -1;
+
+                    Values.Add(new OreOccurence(key[0], RelativeDensity.Poor, absolute));
+                }
+                else if (split[i].StartsWith("Decent"))
+                {
+                    string[] key = split[i].Substring(7).Split(keySeperator, System.StringSplitOptions.RemoveEmptyEntries);
+                    if (!System.Single.TryParse(key[1].Replace(',', '.'), out float absolute))
+                        absolute = -1;
+
+                    Values.Add(new OreOccurence(key[0], RelativeDensity.Decent, absolute));
+                }
+                else if (split[i].StartsWith("High"))
+                {
+                    string[] key = split[i].Substring(5).Split(keySeperator, System.StringSplitOptions.RemoveEmptyEntries);
+                    if (!System.Single.TryParse(key[1].Replace(',', '.'), out float absolute))
+                        absolute = -1;
+
+                    Values.Add(new OreOccurence(key[0], RelativeDensity.High, absolute));
+                }
+                else if (split[i].StartsWith("Very high"))
+                {
+                    string[] key = split[i].Substring(10).Split(keySeperator, System.StringSplitOptions.RemoveEmptyEntries);
+                    if (!System.Single.TryParse(key[1].Replace(',', '.'), out float absolute))
+                        absolute = -1;
+
+                    Values.Add(new OreOccurence(key[0], RelativeDensity.VeryHigh, absolute));
+                }
+                else if (split[i].StartsWith("Ultra high"))
+                {
+                    string[] key = split[i].Substring(11).Split(keySeperator, System.StringSplitOptions.RemoveEmptyEntries);
+                    if (!System.Single.TryParse(key[1].Replace(',', '.'), out float absolute))
+                        absolute = -1;
+
+                    Values.Add(new OreOccurence(key[0], RelativeDensity.UltraHigh, absolute));
+                }
+            }
+        }
+
+        public RelativeDensity GetValueOfOre(string oreName)
+        {
+            foreach (var ore in Values)
+            {
+                if (ore.name == oreName)
+                    return ore.relativeDensity;
+            }
+            return RelativeDensity.Zero;
+        }
     }
 
+    internal struct OreOccurence
+    {
+        public string name;
+        public RelativeDensity relativeDensity;
+        public float absoluteDensity;
+
+        public OreOccurence(string name, RelativeDensity relativeDensity, float absoluteDensity)
+        {
+            this.name = name;
+            this.relativeDensity = relativeDensity;
+            this.absoluteDensity = absoluteDensity;
+        }
+    }
+
+    internal enum RelativeDensity
+    {
+        Zero,
+        Miniscule,
+        VeryPoor,
+        Poor,
+        Decent,
+        High,
+        VeryHigh,
+        UltraHigh
+    }
 }

--- a/src/Map/ProspectorInfos.cs
+++ b/src/Map/ProspectorInfos.cs
@@ -2,7 +2,7 @@
 
 namespace ProspectorInfo.Map
 {
-    class ProspectorMessages : List<ProspectInfo>
+    class ProspectorInfos : List<ProspectInfo>
     {
     }
 }

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -2,14 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using Foundation.Extensions;
 using HarmonyLib;
 using ProspectorInfo.Models;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
-using Vintagestory.API.Config;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Server;
 using Vintagestory.API.Util;
@@ -28,7 +26,7 @@ namespace ProspectorInfo.Map
 
         private const string Filename = ProspectorInfoModSystem.DATAFILE;
         private readonly int _chunksize;
-        private readonly IWorldMapManager _worldMapManager;
+        static private IWorldMapManager _worldMapManager;
         private bool _temporaryRenderOverride = false;
 
         public override string Title => "ProspectorOverlay";
@@ -89,6 +87,18 @@ namespace ProspectorInfo.Map
                         _config.RenderTexturesOnMap = !_config.RenderTexturesOnMap;
 
                     _config.Save(api);
+                    break;
+                case "showgui":
+                    // Auto-sized dialog at the center of the screen
+                    ElementBounds dialogBounds = ElementStdBounds.AutosizedMainDialog.WithAlignment(EnumDialogArea.CenterMiddle);
+
+                    // Just a simple 300x300 pixel box
+                    ElementBounds textBounds = ElementBounds.Fixed(0, 0, 300, 300);
+
+                    GuiComposer SingleComposer = _clientApi.Gui.CreateCompo("ProspectInfo Settings", dialogBounds)
+                        .AddStaticText("This is a piece of text at the center of your screen - Enjoy!", CairoFont.WhiteDetailText(), textBounds)
+                        .Compose()
+                    ;
                     break;
                 case "setcolor":
                     try
@@ -427,7 +437,7 @@ namespace ProspectorInfo.Map
             static void Postfix(IWorldAccessor world, Entity byEntity, ItemSlot itemslot, BlockSelection blockSel)
             {
                 // Only needed to be compatible with https://github.com/Spoonail-Iroiro/VSOneshotPropickMod Version 1.0.0
-                // TODO Should be removed once VSOneshotPropickMod get updated and the "compatibility code" gets removed
+                // TODO Should be removed once VSOneshotPropickMod gets updated and the "compatibility code" gets removed
                 // Dont forget to rename RealPrintProbeResultsPatch back to PrintProbeResultsPatch
             }
         }

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -217,6 +217,16 @@ namespace ProspectorInfo.Map
                             _clientApi.ShowChatMessage(".pi setcolor [0-255] [0-255] [0-255] [0-255] - Sets the color of the overlay tiles.");
                             _clientApi.ShowChatMessage("Command version of config \"TextureColor\". Default config: 7 52 91 50");
                             break;
+                        case "setlowheatcolor":
+                            _clientApi.ShowChatMessage(".pi setlowheatcolor [0-255] [0-255] [0-255] [0-255] - Sets the low heat RGBA color of the overlay tiles for the heatmap.");
+                            _clientApi.ShowChatMessage("Gets blended with \"sethighheatcolor\" based on the relative density of a ore");
+                            _clientApi.ShowChatMessage("Command version of config \"setlowheatcolor\". Default config: 85 85 181 128");
+                            break;
+                        case "sethighheatcolor":
+                            _clientApi.ShowChatMessage(".pi sethighheatcolor [0-255] [0-255] [0-255] [0-255] - Sets the high heat RGBA color of the overlay tiles for the heatmap.");
+                            _clientApi.ShowChatMessage("Gets blended with \"setlowheatcolor\" based on the relative density of a ore");
+                            _clientApi.ShowChatMessage("Command version of config \"sethighheatcolor\". Default config: 168 34 36 128");
+                            break;
                         case "setbordercolor":
                             _clientApi.ShowChatMessage(".pi setbordercolor [0-255] [0-255] [0-255] [0-255] - Sets the color of the tile outlines.");
                             _clientApi.ShowChatMessage("Command version of config \"BorderColor\". Default config: 0 0 0 200");
@@ -229,13 +239,27 @@ namespace ProspectorInfo.Map
                             _clientApi.ShowChatMessage(".pi toggleborder [true,false] - Shows or hides the tile border.");
                             _clientApi.ShowChatMessage("Command version of config \"RenderBorder\". Default config: true");
                             break;
+                        case "mode":
+                            _clientApi.ShowChatMessage(".pi mode [0-1] - Sets the map mode");
+                            _clientApi.ShowChatMessage("Supported modes: 0 (Default) and 1 (Heatmap)");
+                            break;
+                        case "heatmapore":
+                            _clientApi.ShowChatMessage(".pi heatmapore [oreName] - Changes the heatmap mode to display a specific ore");
+                            _clientApi.ShowChatMessage("No argument resets the heatmap back to all ores. Can only handle the english name of an ore without spaces.");
+                            _clientApi.ShowChatMessage("E.g. cassiterite, bituminouscoal, nativecopper");
+                            break;
                         default:
                             _clientApi.ShowChatMessage(".pi - Defaults to \"showoverlay\" without arguments.");
                             _clientApi.ShowChatMessage(".pi showoverlay [bool] - Shows or hides the overlay. No argument toggles instead.");
+                            _clientApi.ShowChatMessage(".pi showgui [bool] - Shows or hides the gui whenever the map is open. No argument toggles instead.");
                             _clientApi.ShowChatMessage(".pi setcolor [0-255] [0-255] [0-255] [0-255] - Sets the RGBA color of the overlay tiles.");
+                            _clientApi.ShowChatMessage(".pi setlowheatcolor [0-255] [0-255] [0-255] [0-255] - Sets the low heat RGBA color of the overlay tiles for the heatmap.");
+                            _clientApi.ShowChatMessage(".pi sethighheatcolor [0-255] [0-255] [0-255] [0-255] - Sets the high heat RGBA color of the overlay tiles for the heatmap.");
                             _clientApi.ShowChatMessage(".pi setbordercolor [0-255] [0-255] [0-255] [0-255] - Sets the RGBA color of the tile outlines.");
                             _clientApi.ShowChatMessage(".pi setborderthickness [int] - Sets the tile outline's thickness.");
                             _clientApi.ShowChatMessage(".pi toggleborder [true,false] - Shows or hides the tile border.");
+                            _clientApi.ShowChatMessage(".pi mode [0-1] - Sets the map mode");
+                            _clientApi.ShowChatMessage(".pi heatmapore [oreName] - Changes the heatmap mode to display a specific ore");
                             _clientApi.ShowChatMessage(".pi help [command] - Shows command's help. Defaults to listing .pi subcommands.");
                             break;
                     }

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -162,42 +162,6 @@ namespace ProspectorInfo.Map
                         _clientApi.ShowChatMessage(e.Message);
                     }
                     break;
-                case "setlowheatcolor":
-                    try
-                    {
-                        var newColor = TrySetRGBAValues(args, _config.BorderColor);
-                        _config.LowHeatColor = newColor;
-                        _config.Save(api);
-
-                        RebuildMap(true);
-                    }
-                    catch (FormatException e)
-                    {
-                        _clientApi.ShowChatMessage(e.Message);
-                    }
-                    catch (ArgumentException e)
-                    {
-                        _clientApi.ShowChatMessage(e.Message);
-                    }
-                    break;
-                case "sethighheatcolor":
-                    try
-                    {
-                        var newColor = TrySetRGBAValues(args, _config.BorderColor);
-                        _config.HighHeatColor = newColor;
-                        _config.Save(api);
-
-                        RebuildMap(true);
-                    }
-                    catch (FormatException e)
-                    {
-                        _clientApi.ShowChatMessage(e.Message);
-                    }
-                    catch (ArgumentException e)
-                    {
-                        _clientApi.ShowChatMessage(e.Message);
-                    }
-                    break;
                 case "setborderthickness":
                     var newThickness = args.PopInt(2).Value;
                     _config.BorderThickness = newThickness;

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -76,11 +76,8 @@ namespace ProspectorInfo.Map
 
         public static void SetInfo(double ppt, double totalFactor, KeyValuePair<string, Vintagestory.API.Datastructures.IntDataMap2D> ore)
         {
-            System.Diagnostics.Debug.WriteLine(ore.Key + " ppt: " + ppt + ", total: " + totalFactor);
             if (_currentProspectingInfo != null && totalFactor > 0.002)
-            {
                 _currentProspectingInfo.AddDepositValues(totalFactor, ppt, ore.Key);
-            }
         }
 
 

--- a/src/ModConfig.cs
+++ b/src/ModConfig.cs
@@ -17,5 +17,6 @@ namespace ProspectorInfo
         public bool AutoToggle { get; set; } = true;
         public int MapMode { get; set; } = 0;
         public string HeatMapOre { get; set; } = null;
+        public bool ShowGui { get; set; } = true;
     }
 }

--- a/src/ModConfig.cs
+++ b/src/ModConfig.cs
@@ -9,9 +9,13 @@ namespace ProspectorInfo
 
         public bool RenderTexturesOnMap { get; set; } = false;
         public ColorWithAlpha TextureColor { get; set; } = new ColorWithAlpha(150, 125, 150, 128);
+        public ColorWithAlpha LowHeatColor { get; set; } = new ColorWithAlpha(85, 85, 181, 128);
+        public ColorWithAlpha HighHeatColor { get; set; } = new ColorWithAlpha(168, 34, 36, 128);
         public ColorWithAlpha BorderColor { get; set; } = new ColorWithAlpha(0, 0, 0, 200);
         public int BorderThickness { get; set; } = 1;
         public bool RenderBorder { get; set; } = true;
         public bool AutoToggle { get; set; } = true;
+        public int MapMode { get; set; } = 0;
+        public string HeatMapOre { get; set; } = null;
     }
 }


### PR DESCRIPTION
This PR adds a small GUI element to the map (opens and closes together with the map) to allow for easy access to the `mode` and `heatmapore` settings. I did not add the color settings to it as it would take quite some work and wouldn't be that useful anyway. This PR depends on #4 and thus contains its whole code too. Either only merge this one or #4 first.

![gui](https://user-images.githubusercontent.com/24532072/184825409-f894f585-168d-4863-ae0c-cc2830c05f03.PNG)
