### PR TITLE
Multilingual heatmap

### DIFF
--- a/src/Map/GuiProspectorInfoSettings.cs
+++ b/src/Map/GuiProspectorInfoSettings.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vintagestory.API.Client;
+
+namespace ProspectorInfo.Map
+{
+    public class GuiProspectorInfoSetting : GuiDialog
+    {
+        public override string ToggleKeyCombinationCode => "prospectorinfosettings";
+        private readonly ModConfig _config;
+        private readonly Action<bool> _rebuildMap;
+        private List<KeyValuePair<string, string>> _ores;
+
+        public GuiProspectorInfoSetting(ICoreClientAPI capi, ModConfig config, Action<bool> rebuildMap) : base(capi)
+        {
+            _config = config;
+            _rebuildMap = rebuildMap;
+            _ores = ProspectInfo.FoundOres.OrderBy((pair) => pair.Key).ToList();
+            _ores.Insert(0, new KeyValuePair<string, string>("All ores", null));
+            SetupDialog();
+        }
+
+        public override bool TryOpen()
+        {
+            if (_ores.Count != ProspectInfo.FoundOres.Count() + 1)
+            {
+                _ores = ProspectInfo.FoundOres.OrderBy((pair) => pair.Key).ToList();
+                _ores.Insert(0, new KeyValuePair<string, string>("All ores", null));
+                SetupDialog();
+            }
+            
+            return base.TryOpen();
+        }
+
+        private void SetupDialog()
+        {
+            // Auto-sized dialog at the center of the screen
+            ElementBounds dialogBounds = ElementStdBounds.AutosizedMainDialog.WithAlignment(EnumDialogArea.RightMiddle);
+            ElementBounds backgroundBounds = ElementBounds.Fill.WithFixedPadding(GuiStyle.ElementToDialogPadding);
+            ElementBounds dialogContainerBounds = ElementBounds.Fixed(0, 40, 150, 150);
+            backgroundBounds.BothSizing = ElementSizing.FitToChildren;
+            backgroundBounds.WithChildren(dialogContainerBounds);
+
+            ElementBounds showOverlayTextBounds = ElementBounds.Fixed(35, 50);
+            ElementBounds switchBounds = ElementBounds.Fixed(125, 50);
+            ElementBounds mapModeBounds = ElementBounds.Fixed(35, 100, 120, 20);
+            ElementBounds oreBounds = ElementBounds.Fixed(35, 130, 120, 20);
+
+            var currentHeatmapOreIndex = 0;
+            if (_config.HeatMapOre != null)
+            {
+                currentHeatmapOreIndex = _ores.FindIndex((pair) => pair.Value != null && pair.Value.Contains(_config.HeatMapOre));
+                if (currentHeatmapOreIndex == -1) // config.HeatMapOre is not a valid ore name -> reset to all ores
+                    currentHeatmapOreIndex = 0;
+            }
+
+            SingleComposer = capi.Gui.CreateCompo("ProspectorInfo Settings", dialogBounds)
+                .AddShadedDialogBG(backgroundBounds)
+                .AddDialogTitleBar("ProspectorInfo", OnCloseTitleBar)
+                .AddStaticText("Show overlay", CairoFont.WhiteDetailText(), showOverlayTextBounds)
+                .AddSwitch(OnSwitchOverlay, switchBounds, "showOverlaySwitch")
+                .AddDropDown(new string[] { "0", "1" }, new string[] { "Default", "Heatmap" }, _config.MapMode, OnMapModeSelected, mapModeBounds)
+                .AddDropDown(_ores.Select((pair) => pair.Value).ToArray(), _ores.Select((pair) => pair.Key).ToArray(), currentHeatmapOreIndex, OnHeatmapOreSelected, oreBounds)
+                .Compose();
+
+            SingleComposer.GetSwitch("showOverlaySwitch").On = _config.RenderTexturesOnMap;
+        }
+
+        private void OnCloseTitleBar()
+        {
+            _config.ShowGui = false;
+            _config.Save(capi);
+            TryClose();
+        }
+
+        private void OnSwitchOverlay(bool value)
+        {
+            _config.RenderTexturesOnMap = value;
+            _config.Save(capi);
+            _rebuildMap(true);
+        }
+
+        private void OnMapModeSelected(string code, bool selected)
+        {
+            _config.MapMode = int.Parse(code);
+            _config.Save(capi);
+            _rebuildMap(true);
+        }
+
+        private void OnHeatmapOreSelected(string code, bool selected)
+        {
+            _config.HeatMapOre = code;
+            _config.Save(capi);
+            _rebuildMap(true);
+        }
+    }
+}

--- a/src/Map/GuiProspectorInfoSettings.cs
+++ b/src/Map/GuiProspectorInfoSettings.cs
@@ -60,7 +60,7 @@ namespace ProspectorInfo.Map
                 .AddDialogTitleBar("ProspectorInfo", OnCloseTitleBar)
                 .AddStaticText("Show overlay", CairoFont.WhiteDetailText(), showOverlayTextBounds)
                 .AddSwitch(OnSwitchOverlay, switchBounds, "showOverlaySwitch")
-                .AddDropDown(new string[] { "0", "1" }, new string[] { "Default", "Heatmap" }, _config.MapMode, OnMapModeSelected, mapModeBounds)
+                .AddDropDown(new string[] { "0", "1" }, new string[] { "Default", "Heatmap" }, (int)_config.MapMode, OnMapModeSelected, mapModeBounds)
                 .AddDropDown(_ores.Select((pair) => pair.Value).ToArray(), _ores.Select((pair) => pair.Key).ToArray(), currentHeatmapOreIndex, OnHeatmapOreSelected, oreBounds)
                 .Compose();
 
@@ -83,7 +83,7 @@ namespace ProspectorInfo.Map
 
         private void OnMapModeSelected(string code, bool selected)
         {
-            _config.MapMode = int.Parse(code);
+            _config.MapMode = (MapMode)int.Parse(code);
             _config.Save(capi);
             _rebuildMap(true);
         }

--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -97,7 +97,6 @@ namespace ProspectorInfo.Map
                 // Sadly, applying the cleanup regex makes this message unparsable in the future.
                 Message = _cleanupRegex.Replace(message, string.Empty);
             }
-            
         }
 
         public bool Equals(ProspectInfo other)

--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -122,7 +122,7 @@ namespace ProspectorInfo.Map
                 foundOres.Add(val.Name);
         }
 
-        public string GetMessage(bool withoutHandbook = true)
+        public string GetMessage()
         {
             StringBuilder sb = new StringBuilder();
 
@@ -138,18 +138,14 @@ namespace ProspectorInfo.Map
                     if (elem.RelativeDensity > RelativeDensity.Miniscule)
                     {
                         string proPickReading = Lang.Get("propick-reading", Lang.Get(densityStrings[(int)elem.RelativeDensity - 2]), elem.PageCode, Lang.Get(elem.Name), elem.AbsoluteDensity.ToString("0.#"));
-                        if (withoutHandbook)
-                            proPickReading = _cleanupRegex.Replace(proPickReading, string.Empty);
+                        proPickReading = _cleanupRegex.Replace(proPickReading, string.Empty);
                         sb.AppendLine(proPickReading);
                     }
                     else
                     {
                         if (traceCount > 0)
                             sbTrace.Append(", ");
-                        if (withoutHandbook)
-                            sbTrace.Append(Lang.Get(elem.Name));
-                        else
-                            sbTrace.Append(string.Format("<a href=\"handbook://{0}\">{1}</a>", elem.PageCode, Lang.Get(elem.Name)));
+                        sbTrace.Append(Lang.Get(elem.Name));
                         traceCount++;
                     }
                 }

--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -8,11 +8,11 @@ namespace ProspectorInfo.Map
 {
     internal class ProspectInfo
     {
-        public static IEnumerable<KeyValuePair<string, string>> FoundOres { get { return AllOres.Where((pair) => foundOres.Contains(pair.Value)); } }
+        public static IEnumerable<KeyValuePair<string, string>> FoundOres { get { return _allOres.Where((pair) => _foundOres.Contains(pair.Value)); } }
         
-        private static readonly Dictionary<string, string> AllOres = new OreNames();
-        private static readonly HashSet<string> foundOres = new HashSet<string>();
-        private static readonly List<string> densityStrings = new List<string>{ 
+        private static readonly Dictionary<string, string> _allOres = new OreNames();
+        private static readonly HashSet<string> _foundOres = new HashSet<string>();
+        private static readonly List<string> _densityStrings = new List<string>{ 
             "propick-density-verypoor",
             "propick-density-poor",
             "propick-density-decent",
@@ -20,7 +20,7 @@ namespace ProspectorInfo.Map
             "propick-density-veryhigh",
             "propick-density-ultrahigh"
         };
-        private static readonly Dictionary<string, RelativeDensity> translatedDensity = new Dictionary<string, RelativeDensity>{
+        private static readonly Dictionary<string, RelativeDensity> _translatedDensity = new Dictionary<string, RelativeDensity>{
             { Lang.Get("propick-density-verypoor"), RelativeDensity.VeryPoor },
             { Lang.Get("propick-density-poor"), RelativeDensity.Poor },
             { Lang.Get("propick-density-decent"), RelativeDensity.Decent },
@@ -59,7 +59,7 @@ namespace ProspectorInfo.Map
                 Values = new List<OreOccurence>();
             else
                 foreach (var val in values)
-                    foundOres.Add(val.Name);
+                    _foundOres.Add(val.Name);
         }
 
         public ProspectInfo(int x, int z, string message)
@@ -96,11 +96,11 @@ namespace ProspectorInfo.Map
                 Match match = _readingParsingRegex.Match(splits[i]);
                 if (match.Success)
                 {
-                    if (!translatedDensity.TryGetValue(match.Groups["relativeDensity"].Value, out RelativeDensity relativeDensity))
+                    if (!_translatedDensity.TryGetValue(match.Groups["relativeDensity"].Value, out RelativeDensity relativeDensity))
                         relativeDensity = RelativeDensity.Zero;
 
                     Values.Add(new OreOccurence(
-                        AllOres[match.Groups["oreName"].Value],
+                        _allOres[match.Groups["oreName"].Value],
                         match.Groups["pageCode"].Value,
                         relativeDensity,
                         double.Parse(match.Groups["absoluteDensity"].Value)
@@ -110,7 +110,7 @@ namespace ProspectorInfo.Map
                     MatchCollection matches = _tracesParsingRegex.Matches(splits[i]);
                     foreach (Match elem in matches)
                         Values.Add(new OreOccurence(
-                            AllOres[elem.Groups["oreName"].Value],
+                            _allOres[elem.Groups["oreName"].Value],
                             elem.Groups["pageCode"].Value,
                             RelativeDensity.Miniscule,
                             0
@@ -119,7 +119,7 @@ namespace ProspectorInfo.Map
             }
 
             foreach (var val in Values)
-                foundOres.Add(val.Name);
+                _foundOres.Add(val.Name);
         }
 
         public string GetMessage()
@@ -137,7 +137,7 @@ namespace ProspectorInfo.Map
                 {
                     if (elem.RelativeDensity > RelativeDensity.Miniscule)
                     {
-                        string proPickReading = Lang.Get("propick-reading", Lang.Get(densityStrings[(int)elem.RelativeDensity - 2]), elem.PageCode, Lang.Get(elem.Name), elem.AbsoluteDensity.ToString("0.#"));
+                        string proPickReading = Lang.Get("propick-reading", Lang.Get(_densityStrings[(int)elem.RelativeDensity - 2]), elem.PageCode, Lang.Get(elem.Name), elem.AbsoluteDensity.ToString("0.#"));
                         proPickReading = _cleanupRegex.Replace(proPickReading, string.Empty);
                         sb.AppendLine(proPickReading);
                     }

--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -1,16 +1,73 @@
-﻿namespace ProspectorInfo.Map
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Vintagestory.API.Config;
+
+namespace ProspectorInfo.Map
 {
     internal class ProspectInfo
     {
+        public static IEnumerable<KeyValuePair<string, string>> FoundOres { get { return AllOres.Where((pair) => foundOres.Contains(pair.Value)); } }
+        
+        private static readonly Dictionary<string, string> AllOres = new OreNames();
+        private static readonly HashSet<string> foundOres = new HashSet<string>();
+        private static readonly List<string> densityStrings = new List<string>{ 
+            "propick-density-verypoor",
+            "propick-density-poor",
+            "propick-density-decent",
+            "propick-density-high",
+            "propick-density-veryhigh",
+            "propick-density-ultrahigh"
+        };
+        private static readonly Dictionary<string, RelativeDensity> translatedDensity = new Dictionary<string, RelativeDensity>{
+            { Lang.Get("propick-density-verypoor"), RelativeDensity.VeryPoor },
+            { Lang.Get("propick-density-poor"), RelativeDensity.Poor },
+            { Lang.Get("propick-density-decent"), RelativeDensity.Decent },
+            { Lang.Get("propick-density-high"), RelativeDensity.High },
+            { Lang.Get("propick-density-veryhigh"), RelativeDensity.VeryHigh },
+            { Lang.Get("propick-density-ultrahigh"), RelativeDensity.UltraHigh }
+        };
+        private static readonly Regex _cleanupRegex = new Regex("<.*?>", RegexOptions.Compiled);
+        private static readonly Regex _readingParsingRegex = new Regex(
+            Lang.Get("propick-reading", "[?<relativeDensity>.*?]", "[?<pageCode>.*?]", "[?<oreName>.*?]", "[?<absoluteDensity>.*?]")
+                .Replace("/", "\\/")
+                .Replace("(", "\\(")
+                .Replace(")", "\\)")
+                .Replace("[", "(")
+                .Replace("]", ")"), 
+            RegexOptions.Compiled
+        );
+        private static readonly Regex _tracesParsingRegex = new Regex(
+            "<a href=\"handbook:\\/\\/(?<pageCode>.*?)\">(?<oreName>.*?)<\\/a>",
+            RegexOptions.Compiled
+        );
+
         public readonly int X;
         public readonly int Z;
-        public string Message;
+        public readonly List<OreOccurence> Values;
+        private readonly string Message; //Used for backwards compatibility
+
+        [Newtonsoft.Json.JsonConstructor]
+        public ProspectInfo(int x, int z, string message, List<OreOccurence> values)
+        {
+            X = x;
+            Z = z;
+            Values = values;
+            Message = message;
+            if (values == null)
+                Values = new List<OreOccurence>();
+            else
+                foreach (var val in values)
+                    foundOres.Add(val.Name);
+        }
 
         public ProspectInfo(int x, int z, string message)
         {
             X = x;
             Z = z;
-            Message = message;
+            Values = new List<OreOccurence>();
+            ParseMessage(message);
         }
 
         public bool Equals(ProspectInfo other)
@@ -30,6 +87,96 @@
                 return (X * 397) ^ Z;
             }
         }
-    }
 
+        private void ParseMessage(string message)
+        {
+            var splits = message.Split('\n');
+            for (var i = 1; i < splits.Length - 1; i++)
+            {
+                Match match = _readingParsingRegex.Match(splits[i]);
+                if (match.Success)
+                {
+                    if (!translatedDensity.TryGetValue(match.Groups["relativeDensity"].Value, out RelativeDensity relativeDensity))
+                        relativeDensity = RelativeDensity.Zero;
+
+                    Values.Add(new OreOccurence(
+                        AllOres[match.Groups["oreName"].Value],
+                        match.Groups["pageCode"].Value,
+                        relativeDensity,
+                        double.Parse(match.Groups["absoluteDensity"].Value)
+                    ));
+                } else
+                {
+                    MatchCollection matches = _tracesParsingRegex.Matches(splits[i]);
+                    foreach (Match elem in matches)
+                        Values.Add(new OreOccurence(
+                            AllOres[elem.Groups["oreName"].Value],
+                            elem.Groups["pageCode"].Value,
+                            RelativeDensity.Miniscule,
+                            0
+                        ));
+                }
+            }
+
+            foreach (var val in Values)
+                foundOres.Add(val.Name);
+        }
+
+        public string GetMessage(bool withoutHandbook = true)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            if (Values.Count > 0)
+            {
+                sb.AppendLine(Lang.Get("propick-reading-title", Values.Count));
+
+                var sbTrace = new StringBuilder();
+                int traceCount = 0;
+
+                foreach (var elem in Values)
+                {
+                    if (elem.RelativeDensity > RelativeDensity.Miniscule)
+                    {
+                        string proPickReading = Lang.Get("propick-reading", Lang.Get(densityStrings[(int)elem.RelativeDensity - 2]), elem.PageCode, Lang.Get(elem.Name), elem.AbsoluteDensity.ToString("0.#"));
+                        if (withoutHandbook)
+                            proPickReading = _cleanupRegex.Replace(proPickReading, string.Empty);
+                        sb.AppendLine(proPickReading);
+                    }
+                    else
+                    {
+                        if (traceCount > 0)
+                            sbTrace.Append(", ");
+                        if (withoutHandbook)
+                            sbTrace.Append(Lang.Get(elem.Name));
+                        else
+                            sbTrace.Append(string.Format("<a href=\"handbook://{0}\">{1}</a>", elem.PageCode, Lang.Get(elem.Name)));
+                        traceCount++;
+                    }
+                }
+                if (sbTrace.Length != 0)
+                {
+                    sb.Append(Lang.Get("Miniscule amounts of {0}", sbTrace.ToString()));
+                    sb.AppendLine();
+                }
+            }
+            else
+            {
+                if (Message != null)
+                    sb.Append(Message);
+                else
+                    sb.Append(Lang.Get("propick-noreading"));
+            }
+            return sb.ToString();
+        }
+
+        public RelativeDensity GetValueOfOre(string oreName)
+        {
+            foreach (var ore in Values)
+            {
+                if (Lang.Get(ore.Name).ToLower() == oreName.ToLower() || ore.Name.ToLower() == oreName.ToLower())
+                    return ore.RelativeDensity;
+            }
+            return RelativeDensity.Zero;
+        }
+    }
 }

--- a/src/Map/ProspectorMessages.cs
+++ b/src/Map/ProspectorMessages.cs
@@ -1,8 +1,0 @@
-﻿using System.Collections.Generic;
-
-namespace ProspectorInfo.Map
-{
-    class ProspectorMessages : List<ProspectInfo>
-    {
-    }
-}

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -496,18 +496,19 @@ namespace ProspectorInfo.Map
         {
             static void Postfix()
             {
-                if (_settingsDialog.IsOpened()) 
-                    _settingsDialog.TryClose();
+                _settingsDialog.TryClose();
             }
         }
 
         [HarmonyPatch(typeof(GuiDialogWorldMap), "Open")]
         class GuiDialogWorldMapOpenPatch
         {
-            static void Postfix()
+            static void Postfix(EnumDialogType type)
             {
-                if (_config.ShowGui) 
+                if (_config.ShowGui && type == EnumDialogType.Dialog) 
                     _settingsDialog.TryOpen();
+                else
+                    _settingsDialog.TryClose();
             }
         }
 

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -194,7 +194,7 @@ namespace ProspectorInfo.Map
                     break;
                 case "mode":
                     var newMode = args.PopInt(2).Value;
-                    _config.MapMode = newMode;
+                    _config.MapMode = (MapMode)newMode;
                     _config.Save(api);
 
                     RebuildMap(true);
@@ -363,7 +363,7 @@ namespace ProspectorInfo.Map
         {
             var colorTexture = new LoadedTexture(_clientApi, 0, _chunksize, _chunksize);
             int[] colorArray;
-            if (_config.MapMode == 1)
+            if (_config.MapMode == MapMode.Heatmap)
                 colorArray = Enumerable.Repeat(ColorUtil.ColorOverlay(_config.LowHeatColor.RGBA, _config.HighHeatColor.RGBA, 1 * (int)relativeDensity / 8.0f), _chunksize * _chunksize).ToArray();
             else
                 colorArray = Enumerable.Repeat(_config.TextureColor.RGBA, _chunksize * _chunksize).ToArray();

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -408,7 +408,7 @@ namespace ProspectorInfo.Map
             var newProspectInfo = new ProspectInfo(posX, posZ, message);
             _prospectInfos.RemoveAll(m => m.X == posX && m.Z == posZ);
             _prospectInfos.Add(newProspectInfo);
-            _clientApi.SaveDataFile(Filename, _prospectInfos);
+            _clientApi.SaveDataFile(Filename, _prospectInfos); //TODO saving the data every time is quite overkill. Should use a more efficient approach.
 
             _components.RemoveAll(component =>
             {

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -405,8 +405,9 @@ namespace ProspectorInfo.Map
 
             var posX = pos.X / _chunksize;
             var posZ = pos.Z / _chunksize;
+            var newProspectInfo = new ProspectInfo(posX, posZ, message);
             _prospectInfos.RemoveAll(m => m.X == posX && m.Z == posZ);
-            _prospectInfos.Add(new ProspectInfo(posX, posZ, message));
+            _prospectInfos.Add(newProspectInfo);
             _clientApi.SaveDataFile(Filename, _prospectInfos);
 
             _components.RemoveAll(component =>
@@ -417,14 +418,14 @@ namespace ProspectorInfo.Map
 
             RelativeDensity densityValue;
             if (_config.HeatMapOre == null)
-                if (_prospectInfos.Last().Values != null && _prospectInfos.Last().Values.Count > 0)
-                    densityValue = _prospectInfos.Last().Values.First().RelativeDensity;
+                if (newProspectInfo.Values != null && newProspectInfo.Values.Count > 0)
+                    densityValue = newProspectInfo.Values.First().RelativeDensity;
                 else
                     densityValue = RelativeDensity.Zero;
             else
-                densityValue = _prospectInfos.Last().GetValueOfOre(_config.HeatMapOre);
+                densityValue = newProspectInfo.GetValueOfOre(_config.HeatMapOre);
 
-            var newComponent = new ProspectorOverlayMapComponent(_clientApi, posX, posZ, _prospectInfos.Last().GetMessage(), _colorTextures[(int)densityValue]);
+            var newComponent = new ProspectorOverlayMapComponent(_clientApi, posX, posZ, newProspectInfo.GetMessage(), _colorTextures[(int)densityValue]);
             _components.Add(newComponent);
 
             blocksSinceLastSuccessList.Clear();

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -416,16 +416,7 @@ namespace ProspectorInfo.Map
                 return castComponent?.ChunkX == posX && castComponent.ChunkZ == posZ;
             });
 
-            RelativeDensity densityValue;
-            if (_config.HeatMapOre == null)
-                if (newProspectInfo.Values != null && newProspectInfo.Values.Count > 0)
-                    densityValue = newProspectInfo.Values.First().RelativeDensity;
-                else
-                    densityValue = RelativeDensity.Zero;
-            else
-                densityValue = newProspectInfo.GetValueOfOre(_config.HeatMapOre);
-
-            var newComponent = new ProspectorOverlayMapComponent(_clientApi, posX, posZ, newProspectInfo.GetMessage(), _colorTextures[(int)densityValue]);
+            var newComponent = new ProspectorOverlayMapComponent(_clientApi, posX, posZ, newProspectInfo.GetMessage(), _colorTextures[(int)GetRelativeDensity(newProspectInfo)]);
             _components.Add(newComponent);
 
             blocksSinceLastSuccessList.Clear();
@@ -457,19 +448,22 @@ namespace ProspectorInfo.Map
                 }
             }
 
-            foreach (var message in _prospectInfos)
+            foreach (var info in _prospectInfos)
             {
-                RelativeDensity densityValue;
-                if (_config.HeatMapOre == null)
-                    if (message.Values != null && message.Values.Count > 0)
-                        densityValue = message.Values.First().RelativeDensity;
-                    else
-                        densityValue = RelativeDensity.Zero;
-                else
-                    densityValue = message.GetValueOfOre(_config.HeatMapOre);
-                var component = new ProspectorOverlayMapComponent(_clientApi, message.X, message.Z, message.GetMessage(), _colorTextures[(int)densityValue]);
+                var component = new ProspectorOverlayMapComponent(_clientApi, info.X, info.Z, info.GetMessage(), _colorTextures[(int)GetRelativeDensity(info)]);
                 _components.Add(component);
             }
+        }
+
+        private RelativeDensity GetRelativeDensity(ProspectInfo prospectInfo)
+        {
+            if (_config.HeatMapOre == null)
+                if (prospectInfo.Values != null && prospectInfo.Values.Count > 0)
+                    return prospectInfo.Values.First().RelativeDensity;
+                else
+                    return RelativeDensity.Zero;
+            else
+                return prospectInfo.GetValueOfOre(_config.HeatMapOre);
         }
 
         public override void OnMouseMoveClient(MouseEvent args, GuiElementMap mapElem, StringBuilder hoverText)

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -249,8 +249,8 @@ namespace ProspectorInfo.Map
                             break;
                         case "heatmapore":
                             _clientApi.ShowChatMessage(".pi heatmapore [oreName] - Changes the heatmap mode to display a specific ore");
-                            _clientApi.ShowChatMessage("No argument resets the heatmap back to all ores. Can only handle the english name of an ore without spaces.");
-                            _clientApi.ShowChatMessage("E.g. cassiterite, bituminouscoal, nativecopper");
+                            _clientApi.ShowChatMessage("No argument resets the heatmap back to all ores. Can only handle the ore name in your selected language or the ore tag.");
+                            _clientApi.ShowChatMessage("E.g. game:ore-emerald, game:ore-bituminouscoal, Cassiterite");
                             break;
                         default:
                             _clientApi.ShowChatMessage(".pi - Defaults to \"showoverlay\" without arguments.");

--- a/src/Map/Utils.cs
+++ b/src/Map/Utils.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using Vintagestory.API.Util;
+
+namespace ProspectorInfo.Map
+{
+    internal class ProspectorMessages : List<ProspectInfo> 
+    {
+    }
+
+    internal class OreNames : Dictionary<string, string>
+    {
+        public OreNames()
+        {
+            IDictionary<string, string> oreValues = Vintagestory.API.Config.Lang.GetAllEntries();
+            // game:ore-lapis is a leftover and unused so it can be removed. See https://discord.com/channels/302152934249070593/351624415039193098/1009372460568805427
+            oreValues.RemoveAll((key, val) => !key.Contains(":ore-") || key.CountChars('-') != 1 || key.Contains("_") || key == "game:ore-lapis");
+            foreach (var elem in oreValues)
+                Add(elem.Value, elem.Key);
+        }
+    }
+
+    internal struct OreOccurence
+    {
+        public readonly string Name;
+        public readonly string PageCode;
+        public readonly RelativeDensity RelativeDensity;
+        public readonly double AbsoluteDensity;
+
+        [Newtonsoft.Json.JsonConstructor]
+        public OreOccurence(string name, string pageCode, RelativeDensity relativeDensity, double absoluteDensity)
+        {
+            Name = name;
+            PageCode = pageCode;
+            RelativeDensity = relativeDensity;
+            AbsoluteDensity = absoluteDensity;
+        }
+    }
+
+    internal enum RelativeDensity
+    {
+        Zero,
+        Miniscule,
+        VeryPoor,
+        Poor,
+        Decent,
+        High,
+        VeryHigh,
+        UltraHigh
+    }
+}

--- a/src/Map/Utils.cs
+++ b/src/Map/Utils.cs
@@ -47,4 +47,10 @@ namespace ProspectorInfo.Map
         VeryHigh,
         UltraHigh
     }
+
+    public enum MapMode
+    {
+        Default,
+        Heatmap
+    }
 }

--- a/src/ModConfig.cs
+++ b/src/ModConfig.cs
@@ -9,9 +9,14 @@ namespace ProspectorInfo
 
         public bool RenderTexturesOnMap { get; set; } = false;
         public ColorWithAlpha TextureColor { get; set; } = new ColorWithAlpha(150, 125, 150, 128);
+        public ColorWithAlpha LowHeatColor { get; set; } = new ColorWithAlpha(85, 85, 181, 128);
+        public ColorWithAlpha HighHeatColor { get; set; } = new ColorWithAlpha(168, 34, 36, 128);
         public ColorWithAlpha BorderColor { get; set; } = new ColorWithAlpha(0, 0, 0, 200);
         public int BorderThickness { get; set; } = 1;
         public bool RenderBorder { get; set; } = true;
         public bool AutoToggle { get; set; } = true;
+        public int MapMode { get; set; } = 0;
+        public string HeatMapOre { get; set; } = null;
+        public bool ShowGui { get; set; } = true;
     }
 }

--- a/src/ModConfig.cs
+++ b/src/ModConfig.cs
@@ -1,4 +1,5 @@
 ﻿using Foundation.ModConfig;
+using ProspectorInfo.Map;
 using ProspectorInfo.Models;
 
 namespace ProspectorInfo
@@ -15,7 +16,7 @@ namespace ProspectorInfo
         public int BorderThickness { get; set; } = 1;
         public bool RenderBorder { get; set; } = true;
         public bool AutoToggle { get; set; } = true;
-        public int MapMode { get; set; } = 0;
+        public MapMode MapMode { get; set; } = MapMode.Default;
         public string HeatMapOre { get; set; } = null;
         public bool ShowGui { get; set; } = true;
     }


### PR DESCRIPTION
This PR is the final version of the heatmap. It contains the heatmap from #4 and the GUI from #7 and is based on the chat message like ProspectorInfo was before (Fully client side based again). It assumes that the prospecting message is in the same language as selected by the client. This is only guaranteed in [1.17.0-rc.8](https://www.vintagestory.at/blog.html/news/de-jank-and-game-juice-update-1170-rc8-r328/) and above. It works in older versions if the client selects the same language as the server though.

Some tweaks compared to the other two versions:
- GUI closes now every time the map is closed
- GUI only shows ores as selectable which have been found already