### PR TITLE
Important fix

### DIFF
--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -59,6 +59,7 @@ namespace ProspectorInfo.Map
         /// <summary>
         /// The prospecting message that was send by the server. Used for backwards compatibitly and when parsing errors occur.
         /// </summary>
+        [Newtonsoft.Json.JsonProperty]
         private string Message;
 
         /// <summary>


### PR DESCRIPTION
I didn't realize that Newtonsoft does not serialize private fields...
Without this fix, the existing prospecting info in an old world is deleted as soon as a new node is prospected.

Should be released asap