### PR TITLE
Language fixes

### DIFF
--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -136,9 +136,9 @@ namespace ProspectorInfo.Map
             // We have to remove the header before splitting as some languages (looking at you Slovensky) have a line break in their header
             string[] splits = message.Replace(headerMatch.Value, string.Empty).Split('\n');
 
-            for (int i = 0; i < splits.Length - 1; i++)
+            foreach (var reading in splits)
             {
-                Match match = _readingParsingRegex.Match(splits[i]);
+                Match match = _readingParsingRegex.Match(reading);
                 if (match.Success)
                 {
                     Values.Add(new OreOccurence(
@@ -149,7 +149,7 @@ namespace ProspectorInfo.Map
                     ));
                 } else
                 {
-                    MatchCollection matches = _tracesParsingRegex.Matches(splits[i]);
+                    MatchCollection matches = _tracesParsingRegex.Matches(reading);
                     foreach (Match elem in matches)
                         Values.Add(new OreOccurence(
                             _allOres[elem.Groups["oreName"].Value],

--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -128,16 +128,13 @@ namespace ProspectorInfo.Map
         /// <exception cref="System.FormatException"></exception>
         private void ParseMessage(string message)
         {
-            string[] splits = message.Split('\n');
-
             // If header can not be matched, we are receiving a different locale than our current one is.
-            if (!_headerParsingRegex.IsMatch(splits[0]))
-            {
-                // TODO instead of just saving the message we could check every language to parse this message.
-                // Sadly, applying the cleanup regex makes this message unparsable in the future.
-                Message = _cleanupRegex.Replace(message, string.Empty);
-                return;
-            }
+            var headerMatch = _headerParsingRegex.Match(message);
+            if (!headerMatch.Success)
+                throw new System.FormatException();
+
+            // We have to remove the header before splitting as some languages (looking at you Slovensky) have a line break in their header
+            string[] splits = message.Replace(headerMatch.Value, string.Empty).Split('\n');
 
             for (int i = 1; i < splits.Length - 1; i++)
             {

--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -136,7 +136,7 @@ namespace ProspectorInfo.Map
             // We have to remove the header before splitting as some languages (looking at you Slovensky) have a line break in their header
             string[] splits = message.Replace(headerMatch.Value, string.Empty).Split('\n');
 
-            for (int i = 1; i < splits.Length - 1; i++)
+            for (int i = 0; i < splits.Length - 1; i++)
             {
                 Match match = _readingParsingRegex.Match(splits[i]);
                 if (match.Success)


### PR DESCRIPTION
This PR contains two fixes
First in ProspectorOverlayLayer adding support for Japanese and Chinese as both do not have a trigger word (Chinese has no spaces and Japanese starts with the number of ores instead of a word) 
and second, in ProspectInfo fixing that Slovensky can not be parsed as its propick-reading-title contains a line break