### PR TITLE
Fixed crash on wrongly parsed message

### DIFF
--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -257,7 +257,7 @@ namespace ProspectorInfo.Map
 
             StringBuilder sb = new StringBuilder();
 
-            if (Values.Count > 0)
+            if (Values != null && Values.Count > 0)
             {
                 sb.AppendLine(Lang.Get("propick-reading-title", Values.Count));
 


### PR DESCRIPTION
Fixes #15 
Yea, you were right with `Value` being null.
It happens when the message can not be parsed correctly, maybe because the server is not yet on 1.17? Well doesn't matter should be fixed with this PR.