### PR TITLE
Refactor mod to use new ChatCommands API

### DIFF
--- a/ProspectorInfo.csproj
+++ b/ProspectorInfo.csproj
@@ -8,7 +8,7 @@
     <ExcludeFiles Condition="'$(Configuration)'=='Debug'">**/VintagestoryAPI.*;**/VSCreativeMod.*;**/VSEssentials.*;**/VSSurvivalMod.*;**/Foundation.*</ExcludeFiles>
     <BinaryDir Condition="'$(Configuration)'=='Release'">$(SolutionDir)/release/$(AssemblyName)</BinaryDir>
     <ExcludeFiles Condition="'$(Configuration)'=='Release'">**/VintagestoryAPI.*;**/VSCreativeMod.*;**/VSEssentials.*;**/VSSurvivalMod.*;**/*.pdb;**/Foundation.*</ExcludeFiles>
-    <Version>4.1.3</Version>
+    <Version>4.1.5</Version>
   </PropertyGroup>
   
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Just drop the file into your mods folder. You just need this mod on the client, 
     .pi heatmapore [oreName] - Changes the heatmap mode to display a specific ore.
         No argument resets the heatmap back to all ores. Can only handle the ore name in your selected language or the ore tag.
         Examples: game:ore-emerald, game:ore-bituminouscoal, Cassiterite.
+    .pi setsaveintervalminutes [1-60] - Periodically store the prospecting data every x minutes.
 
 Each command updates the respective configuration option.
 
@@ -31,6 +32,7 @@ Each command updates the respective configuration option.
                               based on the player equipping/unequipping a prospecting pick. Default: true
     HeatMapOre [oreName] - The ore selected for the heatmap.
     MapMode [0-1] - The mode of the map.
+    SaveIntervalMinutes [1-60] - Periodically store the prospecting data every x minutes.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -6,21 +6,31 @@ Just drop the file into your mods folder. You just need this mod on the client, 
 
 ## Commands
 
-    .pi - main command for the mod and the default sub-command is to 'showoverlay', which will toggle the rendering of the texture on the map
-    .pi showoverlay [true,false] - Sending no arguments will simply toggle the value of the RenderTexturesOnMap config option. Sending either true or false, will set the config option to the appropriate value
-    .pi setcolor [0-255] [0-255] [0-255] [0-255] - Set's the value of the TextureColor field in the config & rebuilds the texture.
-    .pi setbordercolor [0-255] [0-255] [0-255] [0-255] - Set's the value of the BorderColor field in the config & rebuilds the texture.
-    .pi setborderthickness [number] - Set the BorderThickness value in the config & rebuilds the texture.
-    .pi toggleborder [true,false] - Set's the `RenderBorder` value in the config & rebuilds the texture.
-    .pi showgui - Shows the GUI where you can configure the mode (default or heatmap) and select the ore that should be heatmapped
+    .pi - main command for the mod and the default sub-command is to 'showoverlay'
+    .pi showoverlay [true,false] - Show or hide the overlay on the map. Toggles without argument.
+    .pi showborder [true,false] - Show or hide the border around chunks. Toggles without argument.
+    .pi showgui [true,false] - Show the GUI where you can configure the mode (default or heatmap) and select the ore that should be heatmapped.
+    .pi setcolor (overlay|border|lowheat|highheat) [0-255] [0-255] [0-255] [0-255] - Sets the color of the respective element.
+    .pi setborderthickness [1-5] - Sets the border thickness. 
+    .pi mode [0-1] - Sets the map mode. Supported modes: 0 (Default) and 1 (Heatmap)
+    .pi heatmapore [oreName] - Changes the heatmap mode to display a specific ore.
+        No argument resets the heatmap back to all ores. Can only handle the ore name in your selected language or the ore tag.
+        Examples: game:ore-emerald, game:ore-bituminouscoal, Cassiterite.
+
+Each command updates the respective configuration option.
 
 ## Configuration
 
-    TextureColor [0-255] [0-255] [0-255] [0-255] - The default color to use for the texture. Default: 7 52 91 50
-    BorderColor [0-255] [0-255] [0-255] [0-255] - The default color to use for the border texture. Default: 0 0 0 200
-    BorderThickness [number] - The thickness, in pixels, of the border color. Default: 1
+    TextureColor [0-255] [0-255] [0-255] [0-255] - The default color to use for the overlay. Default: 150 125 150 128
+    BorderColor [0-255] [0-255] [0-255] [0-255] - The default color to use for the border. Default: 0 0 0 200
+    LowHeatColor [0-255] [0-255] [0-255] [0-255] - Heatmap color for low relative densitry. Default: 85 85 181 128
+    HighHeatColor [0-255] [0-255] [0-255] [0-255] - Heatmap color for low relative densitry. Default: 168 34 36 128
+    BorderThickness [1-5] - The thickness, in pixels, of the border color. Default: 1
     RenderBorder [true,false] - Whether or not to render the border at all. Default: true
-    AutoToggle [true,false] - Whether or not to toggle the texture on map automatically, based on the player equipping/unequipping a prospecting pick. Default: true
+    AutoToggle [true,false] - Whether or not to toggle the overlay on the map automatically, 
+                              based on the player equipping/unequipping a prospecting pick. Default: true
+    HeatMapOre [oreName] - The ore selected for the heatmap.
+    MapMode [0-1] - The mode of the map.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Each command updates the respective configuration option.
                               based on the player equipping/unequipping a prospecting pick. Default: true
     HeatMapOre [oreName] - The ore selected for the heatmap.
     MapMode [0-1] - The mode of the map.
-    SaveIntervalMinutes [1-60] - Periodically store the prospecting data every x minutes.
+    SaveIntervalMinutes [1-60] - Periodically store the prospecting data every x minutes. Default: 1
 
 ## Usage
 

--- a/modinfo.json
+++ b/modinfo.json
@@ -7,6 +7,6 @@
   "side": "client",
   "version": "4.1.5",
   "dependencies": {
-    "game": "1.16.0"
+    "game": "1.18.0"
   }
 }

--- a/modinfo.json
+++ b/modinfo.json
@@ -5,7 +5,7 @@
   "author": "P3t3rix",
   "description": "Adds info to the tooltip for chunks that are already prospected",
   "side": "client",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "dependencies": {
     "game": "1.16.0"
   }

--- a/src/Map/GuiProspectorInfoSettings.cs
+++ b/src/Map/GuiProspectorInfoSettings.cs
@@ -42,7 +42,7 @@ namespace ProspectorInfo.Map
             backgroundBounds.BothSizing = ElementSizing.FitToChildren;
             backgroundBounds.WithChildren(dialogContainerBounds);
 
-            ElementBounds showOverlayTextBounds = ElementBounds.Fixed(35, 50);
+            ElementBounds showOverlayTextBounds = ElementBounds.Fixed(35, 55, 120, 40);
             ElementBounds switchBounds = ElementBounds.Fixed(125, 50);
             ElementBounds mapModeBounds = ElementBounds.Fixed(35, 100, 120, 20);
             ElementBounds oreBounds = ElementBounds.Fixed(35, 130, 120, 20);

--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -65,6 +65,24 @@ namespace ProspectorInfo.Map
         public readonly int Z;
 
         /// <summary>
+        /// We don't want to change the serialization format,
+        /// so we keep the coordinates in a cache.
+        /// </summary>
+        [Newtonsoft.Json.JsonIgnore]
+        private ChunkCoordinates? _coordinates = null;
+        [Newtonsoft.Json.JsonIgnore]
+        public ChunkCoordinates ChunkCoordinates
+        { 
+            get {
+                if (_coordinates == null)
+                {
+                    _coordinates = new ChunkCoordinates(X, Z);
+                }
+                return (ChunkCoordinates)_coordinates;
+            }
+        }
+
+        /// <summary>
         /// A sorted list of all ore occurencies in this chunk. The ore with the highest relative density is first.
         /// </summary>
         public readonly List<OreOccurence> Values;

--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -69,16 +69,16 @@ namespace ProspectorInfo.Map
         /// so we keep the coordinates in a cache.
         /// </summary>
         [Newtonsoft.Json.JsonIgnore]
-        private ChunkCoordinates? _coordinates = null;
+        private ChunkCoordinate? _coordinate = null;
         [Newtonsoft.Json.JsonIgnore]
-        public ChunkCoordinates ChunkCoordinates
+        public ChunkCoordinate ChunkCoordinate
         { 
             get {
-                if (_coordinates == null)
+                if (_coordinate == null)
                 {
-                    _coordinates = new ChunkCoordinates(X, Z);
+                    _coordinate = new ChunkCoordinate(X, Z);
                 }
-                return (ChunkCoordinates)_coordinates;
+                return (ChunkCoordinate)_coordinate;
             }
         }
 

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -157,20 +157,20 @@ namespace ProspectorInfo.Map
 
         private TextCommandResult OnSetColorCommand(TextCommandCallingArgs args)
         {
-            ColorWithAlpha colorUpdate = (ColorWithAlpha) args.Parsers[1].GetValue();
+            ColorWithAlphaUpdate colorUpdate = (ColorWithAlphaUpdate) args.Parsers[1].GetValue();
             switch ((string)args.Parsers[0].GetValue()) 
             {
                 case "overlay":
-                    _config.TextureColor = _config.TextureColor.CopyWith(colorUpdate);
+                    colorUpdate.ApplyUpdateTo(_config.TextureColor);
                     break;
                 case "border":
-                    _config.BorderColor = _config.BorderColor.CopyWith(colorUpdate);
+                    colorUpdate.ApplyUpdateTo(_config.BorderColor);
                     break;
                 case "lowheat":
-                    _config.LowHeatColor = _config.LowHeatColor.CopyWith(colorUpdate);
+                    colorUpdate.ApplyUpdateTo(_config.LowHeatColor);
                     break;
                 case "highheat":
-                    _config.HighHeatColor = _config.HighHeatColor.CopyWith(colorUpdate);
+                    colorUpdate.ApplyUpdateTo(_config.HighHeatColor);
                     break;
                 default:
                     return TextCommandResult.Error("Unknown element to set color for");

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -186,6 +186,7 @@ namespace ProspectorInfo.Map
             else
                 _config.RenderTexturesOnMap = (bool) args.Parsers[0].GetValue();
             _config.Save(api);
+            RebuildMap();
             return TextCommandResult.Success($"Set RenderTexturesOnMap to {_config.RenderTexturesOnMap}.");
         }
 

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -186,7 +186,7 @@ namespace ProspectorInfo.Map
             else
                 _config.RenderTexturesOnMap = (bool) args.Parsers[0].GetValue();
             _config.Save(api);
-            return TextCommandResult.Success();
+            return TextCommandResult.Success($"Set RenderTexturesOnMap to {_config.RenderTexturesOnMap}.");
         }
 
         private TextCommandResult OnShowGuiCommand(TextCommandCallingArgs args)
@@ -198,32 +198,37 @@ namespace ProspectorInfo.Map
             _config.Save(api);
             if (_worldMapManager.IsOpened)
                 _settingsDialog.TryOpen();
-            return TextCommandResult.Success();
+            return TextCommandResult.Success($"Set ShowGui to {_config.ShowGui}.");
         }
 
         private TextCommandResult OnSetColorCommand(TextCommandCallingArgs args)
         {
             ColorWithAlphaUpdate colorUpdate = (ColorWithAlphaUpdate) args.Parsers[1].GetValue();
+            string changedColorSetting;
             switch ((string)args.Parsers[0].GetValue()) 
             {
                 case "overlay":
                     colorUpdate.ApplyUpdateTo(_config.TextureColor);
+                    changedColorSetting = "TextureColor";
                     break;
                 case "border":
                     colorUpdate.ApplyUpdateTo(_config.BorderColor);
+                    changedColorSetting = "BorderColor";
                     break;
                 case "lowheat":
                     colorUpdate.ApplyUpdateTo(_config.LowHeatColor);
+                    changedColorSetting = "LowHeadColor";
                     break;
                 case "highheat":
                     colorUpdate.ApplyUpdateTo(_config.HighHeatColor);
+                    changedColorSetting = "HighHeatColor";
                     break;
                 default:
-                    return TextCommandResult.Error("Unknown element to set color for");
+                    return TextCommandResult.Error("Unknown element to set color for.");
             }
             _config.Save(api);
             RebuildMap(true);
-            return TextCommandResult.Success();
+            return TextCommandResult.Success($"Updated color for {changedColorSetting}.");
         }
 
         private TextCommandResult OnSetBorderThicknessCommand(TextCommandCallingArgs args)
@@ -232,7 +237,7 @@ namespace ProspectorInfo.Map
             _config.BorderThickness = newThickness;
             _config.Save(api);
             RebuildMap(true);
-            return TextCommandResult.Success();
+            return TextCommandResult.Success($"Set BorderThickness to {_config.BorderThickness}.");
         }
 
         private TextCommandResult OnShowBorderCommand(TextCommandCallingArgs args)
@@ -244,7 +249,7 @@ namespace ProspectorInfo.Map
             _config.Save(api);
 
             RebuildMap(true);
-            return TextCommandResult.Success();
+            return TextCommandResult.Success($"Set RenderBorder to {_config.RenderBorder}.");
         }
 
         private TextCommandResult OnSetModeCommand(TextCommandCallingArgs args)
@@ -254,7 +259,7 @@ namespace ProspectorInfo.Map
             _config.Save(api);
 
             RebuildMap(true);
-            return TextCommandResult.Success();
+            return TextCommandResult.Success($"Set MapMode to {_config.MapMode}.");
         }
 
         private TextCommandResult OnHeatmapOreCommand(TextCommandCallingArgs args)
@@ -266,14 +271,14 @@ namespace ProspectorInfo.Map
             _config.Save(api);
 
             RebuildMap(true);
-            return TextCommandResult.Success();
+            return TextCommandResult.Success($"Set HeatMapOre to {_config.HeatMapOre}.");
         }
 
         private TextCommandResult OnSetSaveIntervalMinutes(TextCommandCallingArgs args)
         {
             _config.SaveIntervalMinutes = (int)args.Parsers[0].GetValue();
             _config.Save(api);
-            return TextCommandResult.Success();
+            return TextCommandResult.Success($"Set SaveIntervalMinutes to {_config.SaveIntervalMinutes}.");
         }
 
         private void Event_SlotModified(int slotId)

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Foundation.Extensions;
 using HarmonyLib;
-using ProspectorInfo.Models;
 using ProspectorInfo.Utils;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
@@ -116,6 +116,13 @@ namespace ProspectorInfo.Map
                                          "E.g. game:ore-emerald, game:ore-bituminouscoal, Cassiterite")
                         .WithArgs(api.ChatCommands.Parsers.OptionalWord("oreName"))
                         .HandleWith(OnHeatmapOreCommand)
+                    .EndSubCommand()
+                    .BeginSubCommand("setsaveintervalminutes")
+                        .WithDescription(".pi setsaveintervalminutes [int] - How often should the prospecting data be saved to disk.<br/>" +
+                                         "Requires leaving/reentering the world. The data is also saved when leaving a world.<br/>" +
+                                         "Sets the \"SaveIntervalMinutes\" config option (default = 1)")
+                        .WithArgs(api.ChatCommands.Parsers.IntRange("interval", 1, 60))
+                        .HandleWith(OnSetSaveIntervalMinutes)
                     .EndSubCommand();
 
                 for (int i = 0; i < _colorTextures.Length; i++)
@@ -229,6 +236,13 @@ namespace ProspectorInfo.Map
             _config.Save(api);
 
             RebuildMap(true);
+            return TextCommandResult.Success();
+        }
+
+        private TextCommandResult OnSetSaveIntervalMinutes(TextCommandCallingArgs args)
+        {
+            _config.SaveIntervalMinutes = (int)args.Parsers[0].GetValue();
+            _config.Save(api);
             return TextCommandResult.Success();
         }
 

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -22,7 +22,7 @@ namespace ProspectorInfo.Map
         private readonly ProspectorMessages _prospectInfos;
         private readonly int _chunksize;
         private readonly ICoreClientAPI _clientApi;
-        private readonly Dictionary<ChunkCoordinates, ProspectorOverlayMapComponent> _components = new Dictionary<ChunkCoordinates, ProspectorOverlayMapComponent>();
+        private readonly Dictionary<ChunkCoordinate, ProspectorOverlayMapComponent> _components = new Dictionary<ChunkCoordinate, ProspectorOverlayMapComponent>();
         private readonly IWorldMapManager _worldMapManager;
         private readonly LoadedTexture[] _colorTextures = new LoadedTexture[8];
         private bool _temporaryRenderOverride = false;
@@ -146,7 +146,7 @@ namespace ProspectorInfo.Map
             var result = new ProspectorMessages();
             foreach (var item in temp)
             {
-                result[item.ChunkCoordinates] = item;
+                result[item.ChunkCoordinate] = item;
             }
             return result;
         }
@@ -167,9 +167,9 @@ namespace ProspectorInfo.Map
             {
                 foreach (ProspectInfo info in information)
                 {
-                    _prospectInfos[info.ChunkCoordinates] = info;
-                    var newComponent = new ProspectorOverlayMapComponent(_clientApi, info.ChunkCoordinates, info.GetMessage(), _colorTextures[(int)GetRelativeDensity(info)]);
-                    _components[info.ChunkCoordinates] = newComponent;
+                    _prospectInfos[info.ChunkCoordinate] = info;
+                    var newComponent = new ProspectorOverlayMapComponent(_clientApi, info.ChunkCoordinate, info.GetMessage(), _colorTextures[(int)GetRelativeDensity(info)]);
+                    _components[info.ChunkCoordinate] = newComponent;
                 }
                 _prospectInfos.HasChanged = true;
             }
@@ -381,8 +381,8 @@ namespace ProspectorInfo.Map
             {
                 foreach (var info in _prospectInfos.Values)
                 {
-                    var component = new ProspectorOverlayMapComponent(_clientApi, info.ChunkCoordinates, info.GetMessage(), _colorTextures[(int)GetRelativeDensity(info)]);
-                    _components[info.ChunkCoordinates] = component;
+                    var component = new ProspectorOverlayMapComponent(_clientApi, info.ChunkCoordinate, info.GetMessage(), _colorTextures[(int)GetRelativeDensity(info)]);
+                    _components[info.ChunkCoordinate] = component;
                 }
             }
         }

--- a/src/Map/ProspectorOverlayMapComponent.cs
+++ b/src/Map/ProspectorOverlayMapComponent.cs
@@ -7,7 +7,7 @@ namespace ProspectorInfo.Map
 {
     public class ProspectorOverlayMapComponent : MapComponent
     {
-        public readonly ChunkCoordinates _chunkCoordinates;
+        public readonly ChunkCoordinate _chunkCoordinates;
         
         private readonly string _message;
         private readonly int _chunksize;
@@ -16,7 +16,7 @@ namespace ProspectorInfo.Map
         private Vec3d worldPos = new Vec3d();
         private Vec2f viewPos = new Vec2f();
 
-        public ProspectorOverlayMapComponent(ICoreClientAPI clientApi, ChunkCoordinates coords, string message, LoadedTexture colorTexture) : base(clientApi)
+        public ProspectorOverlayMapComponent(ICoreClientAPI clientApi, ChunkCoordinate coords, string message, LoadedTexture colorTexture) : base(clientApi)
         {
             this._chunkCoordinates = coords;
             this._message = message;

--- a/src/Map/ProspectorOverlayMapComponent.cs
+++ b/src/Map/ProspectorOverlayMapComponent.cs
@@ -7,9 +7,8 @@ namespace ProspectorInfo.Map
 {
     public class ProspectorOverlayMapComponent : MapComponent
     {
-        public readonly int ChunkX;
-        public readonly int ChunkZ;
-
+        public readonly ChunkCoordinates _chunkCoordinates;
+        
         private readonly string _message;
         private readonly int _chunksize;
 
@@ -17,13 +16,12 @@ namespace ProspectorInfo.Map
         private Vec3d worldPos = new Vec3d();
         private Vec2f viewPos = new Vec2f();
 
-        public ProspectorOverlayMapComponent(ICoreClientAPI clientApi, int chunkX, int chunkZ, string message, LoadedTexture colorTexture) : base(clientApi)
+        public ProspectorOverlayMapComponent(ICoreClientAPI clientApi, ChunkCoordinates coords, string message, LoadedTexture colorTexture) : base(clientApi)
         {
-            this.ChunkX = chunkX;
-            this.ChunkZ = chunkZ;
+            this._chunkCoordinates = coords;
             this._message = message;
             this._chunksize = clientApi.World.BlockAccessor.ChunkSize;
-            this.worldPos = new Vec3d(chunkX * _chunksize, 0, chunkZ * _chunksize);
+            this.worldPos = new Vec3d(coords.X * _chunksize, 0, coords.Z * _chunksize);
             this.colorTexture = colorTexture;
         }
 
@@ -37,7 +35,7 @@ namespace ProspectorInfo.Map
 
             var chunkX = (int)(worldPos.X / _chunksize);
             var chunkZ = (int)(worldPos.Z / _chunksize);
-            if (chunkX == ChunkX && chunkZ == ChunkZ)
+            if (chunkX == _chunkCoordinates.X && chunkZ == _chunkCoordinates.Z)
             {
                 hoverText.AppendLine($"\n{_message}");
             }

--- a/src/Map/Utils.cs
+++ b/src/Map/Utils.cs
@@ -4,6 +4,8 @@ using Vintagestory.API.Util;
 
 namespace ProspectorInfo.Map
 {
+    // Should be a dictionary with coordinates as key, but NewtonSoft Json does not play
+    // nicely with complex objects as key...
     internal class ProspectorMessages : List<ProspectInfo> 
     {
         [JsonIgnore]

--- a/src/Map/Utils.cs
+++ b/src/Map/Utils.cs
@@ -4,7 +4,7 @@ using Vintagestory.API.Util;
 
 namespace ProspectorInfo.Map
 {
-    internal class ProspectorMessages : Dictionary<ChunkCoordinates, ProspectInfo> 
+    internal class ProspectorMessages : Dictionary<ChunkCoordinate, ProspectInfo> 
     {
         [JsonIgnore]
         public bool HasChanged { get; set; } = false;
@@ -57,12 +57,12 @@ namespace ProspectorInfo.Map
         Default,
         Heatmap
     }
-    public struct ChunkCoordinates
+    public struct ChunkCoordinate
     {
         public int X;
         public int Z;
 
-        public ChunkCoordinates(int x, int z)
+        public ChunkCoordinate(int x, int z)
         {
             X = x;
             Z = z;

--- a/src/Map/Utils.cs
+++ b/src/Map/Utils.cs
@@ -4,9 +4,7 @@ using Vintagestory.API.Util;
 
 namespace ProspectorInfo.Map
 {
-    // Should be a dictionary with coordinates as key, but NewtonSoft Json does not play
-    // nicely with complex objects as key...
-    internal class ProspectorMessages : List<ProspectInfo> 
+    internal class ProspectorMessages : Dictionary<ChunkCoordinates, ProspectInfo> 
     {
         [JsonIgnore]
         public bool HasChanged { get; set; } = false;
@@ -58,5 +56,16 @@ namespace ProspectorInfo.Map
     {
         Default,
         Heatmap
+    }
+    public struct ChunkCoordinates
+    {
+        public int X;
+        public int Z;
+
+        public ChunkCoordinates(int x, int z)
+        {
+            X = x;
+            Z = z;
+        }
     }
 }

--- a/src/Models/ColorWithAlpha.cs
+++ b/src/Models/ColorWithAlpha.cs
@@ -5,7 +5,7 @@ namespace ProspectorInfo.Models
 {
     public class ColorWithAlpha
     {
-        public ColorWithAlpha(int r, int g, int b, int a)
+        public ColorWithAlpha(byte r, byte g, byte b, byte a)
         {
             this.Red = r;
             this.Green = g;
@@ -13,21 +13,12 @@ namespace ProspectorInfo.Models
             this.Alpha = a;
         }
 
-        public int Red { get; set; }
-        public int Green { get; set; }
-        public int Blue { get; set; }
-        public int Alpha { get; set; }
+        public byte Red { get; set; }
+        public byte Green { get; set; }
+        public byte Blue { get; set; }
+        public byte Alpha { get; set; }
 
         [JsonIgnore]
         public int RGBA { get => ColorUtil.ToRgba(this.Alpha, this.Blue, this.Green, this.Red); }
-
-        public ColorWithAlpha CopyWith(ColorWithAlpha other)
-        {
-            return new ColorWithAlpha(
-                other.Red == -1 ? Red : other.Red,
-                other.Green == -1 ? Green : other.Green,
-                other.Blue == -1 ? Blue : other.Blue,
-                other.Alpha == -1 ? Alpha : other.Alpha);
-        }
     }
 }

--- a/src/Models/ColorWithAlpha.cs
+++ b/src/Models/ColorWithAlpha.cs
@@ -20,5 +20,14 @@ namespace ProspectorInfo.Models
 
         [JsonIgnore]
         public int RGBA { get => ColorUtil.ToRgba(this.Alpha, this.Blue, this.Green, this.Red); }
+
+        public ColorWithAlpha CopyWith(ColorWithAlpha other)
+        {
+            return new ColorWithAlpha(
+                other.Red == -1 ? Red : other.Red,
+                other.Green == -1 ? Green : other.Green,
+                other.Blue == -1 ? Blue : other.Blue,
+                other.Alpha == -1 ? Alpha : other.Alpha);
+        }
     }
 }

--- a/src/Utils/ColorWithAlphaParser.cs
+++ b/src/Utils/ColorWithAlphaParser.cs
@@ -26,10 +26,10 @@ namespace ProspectorInfo.Utils
 
         public void ApplyUpdateTo(ColorWithAlpha other) 
         {
-            other.Red = red.HasValue ? red.Value : other.Red;
-            other.Green = green.HasValue ? green.Value : other.Green;
-            other.Blue = blue.HasValue ? blue.Value : other.Blue;
-            other.Alpha = alpha.HasValue ? alpha.Value : other.Alpha;
+            other.Red = red ?? other.Red;
+            other.Green = green ?? other.Green;
+            other.Blue = blue ?? other.Blue;
+            other.Alpha = alpha ?? other.Alpha;
         }
     }
     

--- a/src/Utils/ColorWithAlphaParser.cs
+++ b/src/Utils/ColorWithAlphaParser.cs
@@ -1,0 +1,68 @@
+﻿using ProspectorInfo.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Vintagestory.API.Common;
+
+namespace ProspectorInfo.Utils
+{
+    public class ColorWithAlphaArgParser : ArgumentParserBase
+    {
+        private ColorWithAlpha value = new ColorWithAlpha(-1, -1, -1, -1);
+
+        public ColorWithAlphaArgParser(string argName, bool isMandatoryArg) : base(argName, isMandatoryArg)
+        {
+        }
+
+        public override object GetValue()
+        {
+            return value;
+        }
+
+        public override void SetValue(object data)
+        {
+            value = (ColorWithAlpha) data;
+        }
+
+        public override EnumParseResult TryProcess(TextCommandCallingArgs args, Action<AsyncParseResults> onReady = null)
+        {
+            // TODO: In theory this is bad design, because this parser consumes a variable amount of arguments,
+            // so we might 'steal' arguments from a subsequent parser, even though they are not meant for this parser. 
+            // In other words, this parser should always be last.
+            
+            int argCount = args.RawArgs.Length;
+            if (!(argCount == 1 || argCount == 3 || argCount == 4))
+            {
+                lastErrorMessage = "Invalid color format. Specify either R G B A or R G B or only A.";
+                return EnumParseResult.Bad;
+            }
+
+            int[] values = new int[argCount];
+            for (int i = 0; i < values.Length; i++)
+            {
+                var arg = args.RawArgs.PopInt();
+                if (arg == null)
+                {
+                    lastErrorMessage = $"Color component {i+1} is not a number.";
+                    return EnumParseResult.Bad;
+                }
+                if (arg < 0 || arg > 255)
+                {
+                    lastErrorMessage = $"Color component {i+1} must be in range [0-255].";
+                    return EnumParseResult.Bad;
+                }
+                values[i] = arg.Value;
+            }
+
+            if (values.Length == 1)
+                value = new ColorWithAlpha(-1, -1, -1, values[0]);
+            else if (values.Length == 3)
+                value = new ColorWithAlpha(values[0], values[1], values[2], -1);
+            else
+                value = new ColorWithAlpha(values[0], values[1], values[2], values[3]);
+            return EnumParseResult.Good;
+        }
+    }
+}

--- a/src/Utils/ColorWithAlphaParser.cs
+++ b/src/Utils/ColorWithAlphaParser.cs
@@ -8,9 +8,34 @@ using Vintagestory.API.Common;
 
 namespace ProspectorInfo.Utils
 {
+    public class ColorWithAlphaUpdate 
+    {
+
+        private byte? red; 
+        private byte? green; 
+        private byte? blue; 
+        private byte? alpha;
+
+        public ColorWithAlphaUpdate(byte? r, byte? g, byte? b, byte? a)
+        {
+            red = r;
+            green = g;
+            blue = b;
+            alpha = a;
+        }
+
+        public void ApplyUpdateTo(ColorWithAlpha other) 
+        {
+            other.Red = red.HasValue ? red.Value : other.Red;
+            other.Green = green.HasValue ? green.Value : other.Green;
+            other.Blue = blue.HasValue ? blue.Value : other.Blue;
+            other.Alpha = alpha.HasValue ? alpha.Value : other.Alpha;
+        }
+    }
+    
     public class ColorWithAlphaArgParser : ArgumentParserBase
     {
-        private ColorWithAlpha value = new ColorWithAlpha(-1, -1, -1, -1);
+        private ColorWithAlphaUpdate value = new ColorWithAlphaUpdate(null, null, null, null);
 
         public ColorWithAlphaArgParser(string argName, bool isMandatoryArg) : base(argName, isMandatoryArg)
         {
@@ -23,7 +48,7 @@ namespace ProspectorInfo.Utils
 
         public override void SetValue(object data)
         {
-            value = (ColorWithAlpha) data;
+            value = (ColorWithAlphaUpdate) data;
         }
 
         public override EnumParseResult TryProcess(TextCommandCallingArgs args, Action<AsyncParseResults> onReady = null)
@@ -39,7 +64,7 @@ namespace ProspectorInfo.Utils
                 return EnumParseResult.Bad;
             }
 
-            int[] values = new int[argCount];
+            byte[] values = new byte[argCount];
             for (int i = 0; i < values.Length; i++)
             {
                 var arg = args.RawArgs.PopInt();
@@ -53,15 +78,15 @@ namespace ProspectorInfo.Utils
                     lastErrorMessage = $"Color component {i+1} must be in range [0-255].";
                     return EnumParseResult.Bad;
                 }
-                values[i] = arg.Value;
+                values[i] = (byte) arg.Value;
             }
 
             if (values.Length == 1)
-                value = new ColorWithAlpha(-1, -1, -1, values[0]);
+                value = new ColorWithAlphaUpdate(null, null, null, values[0]);
             else if (values.Length == 3)
-                value = new ColorWithAlpha(values[0], values[1], values[2], -1);
+                value = new ColorWithAlphaUpdate(values[0], values[1], values[2], null);
             else
-                value = new ColorWithAlpha(values[0], values[1], values[2], values[3]);
+                value = new ColorWithAlphaUpdate(values[0], values[1], values[2], values[3]);
             return EnumParseResult.Good;
         }
     }


### PR DESCRIPTION
Hi,
I wanted to get a bit into C# and thought that updating this mod to the new 1.18 ChatCommand API should be good practice.
A small summary of the changes:
* Split the large `OnPiCommand` method into smaller methods for each sub command using the new API.
* Implement a small parser to read/validate RGBA color arguments based on the new API.
* Rename `.pi toggleborder` to `.pi showborder` to be consistent with the other similar commands (`showgui`, `showoverlay`)
* Merge the `set*color` commands into a single command, whose first argument determines which color should be changed, e.g., `.pi setcolor overlay 150 125 150 128`
* Update the documentation in `README.md`
* Update the default colors in the description to the defaults in `ModConfig`.

This is still a work in progress, because I'm not sure where/how a user can access/see the newly added information for all the subcommands. I just wanted to give you a heads up that I'm working on this, but I think merging should happen only after the full release of 1.18.
I would also appreciate any feedback :)
