### PR TITLE
Address missing decimal places for absolute densities

### DIFF
--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -48,6 +48,12 @@ namespace ProspectorInfo.Map
             RegexOptions.Compiled
         );
 
+        /// <summary>
+        /// A regex to extract decimal numbers from a string.
+        /// </summary>
+        private static readonly Regex _absoluteDensityRegex = new Regex("([0-9]+[.,]?[0-9]*)", 
+            RegexOptions.Compiled);
+
         public readonly int X;
         public readonly int Z;
 
@@ -223,9 +229,8 @@ namespace ProspectorInfo.Map
 
                 if (relativeDensity != RelativeDensity.Zero) 
                 {
-                    Regex absoluteDensityRegex = new Regex("([0-9]+,?[0-9]*)");
-                    double absoluteDensity = double.Parse(absoluteDensityRegex.Match(reading).Value);
-
+                    double absoluteDensity = double.Parse(_absoluteDensityRegex.Match(reading).Value);
+                    
                     string oreName = null;
                     foreach (var ore in ores)
                         if (reading.Contains(ore.Key))


### PR DESCRIPTION
This hopefully fixes the problem mentioned in #22.

@p3t3rix You were right, `,` and `.` seem to be the most commonly used decimal separators, at least according to the [standard](https://en.wikipedia.org/wiki/Decimal_separator#Current_standards), so I just added `.` as another possible separator to the regex.

As you also mentioned, there might be other problems, e.g., values >= 1000, where digit grouping might come into play. I would argue that this should not be a problem, as the density is given as parts per thousand, so unless you find a chunk which entirely consists of a single ore, you should not get 1000 ‰.