### PR TITLE
Share data via chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Just drop the file into your mods folder. You just need this mod on the client, 
         Examples: game:ore-emerald, game:ore-bituminouscoal, Cassiterite.
     .pi setsaveintervalminutes [1-60] - Periodically store the prospecting data every x minutes.
     .pi share - Share your prospecting data via the chat. Clients with this mod will update their own data based on the new information.
-    .pi aceeptchatsharing true - Accept prospecting data from the chat.
+    .pi acceptchatsharing [true,false] - Accept prospecting data from the chat.
 
 Each command updates the respective configuration option.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Just drop the file into your mods folder. You just need this mod on the client, 
         Examples: game:ore-emerald, game:ore-bituminouscoal, Cassiterite.
     .pi setsaveintervalminutes [1-60] - Periodically store the prospecting data every x minutes.
     .pi share - Share your prospecting data via the chat. Clients with this mod will update their own data based on the new information.
+    .pi aceeptchatsharing true - Accept prospecting data from the chat.
 
 Each command updates the respective configuration option.
 
@@ -34,6 +35,7 @@ Each command updates the respective configuration option.
     HeatMapOre [oreName] - The ore selected for the heatmap.
     MapMode [0-1] - The mode of the map.
     SaveIntervalMinutes [1-60] - Periodically store the prospecting data every x minutes.
+    AcceptChatSharing [bool] - Accept prospecting data shared by other players in the chat? Default: false
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Just drop the file into your mods folder. You just need this mod on the client, 
         No argument resets the heatmap back to all ores. Can only handle the ore name in your selected language or the ore tag.
         Examples: game:ore-emerald, game:ore-bituminouscoal, Cassiterite.
     .pi setsaveintervalminutes [1-60] - Periodically store the prospecting data every x minutes.
+    .pi share - Share your prospecting data via the chat. Clients with this mod will update their own data based on the new information.
 
 Each command updates the respective configuration option.
 

--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -7,6 +7,7 @@ using Vintagestory.API.Config;
 
 namespace ProspectorInfo.Map
 {
+    [ProtoBuf.ProtoContract(ImplicitFields = ProtoBuf.ImplicitFields.None)]
     internal class ProspectInfo
     {
         public static IEnumerable<KeyValuePair<string, string>> FoundOres { get { return _allOres.Where((pair) => _foundOres.Contains(pair.Value)); } }
@@ -61,7 +62,9 @@ namespace ProspectorInfo.Map
         private static readonly Regex _absoluteDensityRegex = new Regex("([0-9]+[.,]?[0-9]*)", 
             RegexOptions.Compiled);
 
+        [ProtoBuf.ProtoMember(1)]
         public readonly int X;
+        [ProtoBuf.ProtoMember(2)]
         public readonly int Z;
 
         /// <summary>
@@ -85,6 +88,7 @@ namespace ProspectorInfo.Map
         /// <summary>
         /// A sorted list of all ore occurencies in this chunk. The ore with the highest relative density is first.
         /// </summary>
+        [ProtoBuf.ProtoMember(3)]
         public readonly List<OreOccurence> Values;
 
         /// <summary>
@@ -98,6 +102,13 @@ namespace ProspectorInfo.Map
         /// </summary>
         [Newtonsoft.Json.JsonIgnore]
         private string _messageCache;
+
+        /// <summary>
+        /// Required for ProtoBuf deserialization
+        /// </summary>
+        private ProspectInfo()
+        {
+        }
 
         [Newtonsoft.Json.JsonConstructor]
         public ProspectInfo(int x, int z, string message, List<OreOccurence> values)

--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -124,8 +124,7 @@ namespace ProspectorInfo.Map
             } 
             else
             {
-                foreach (var val in values)
-                    _foundOres.Add(val.Name);
+                AddFoundOres();
             }            
         }
 
@@ -162,6 +161,12 @@ namespace ProspectorInfo.Map
             {
                 return (X * 397) ^ Z;
             }
+        }
+
+        public void AddFoundOres()
+        {
+            foreach (var val in Values)
+                _foundOres.Add(val.Name);
         }
 
         /// <summary>
@@ -220,8 +225,7 @@ namespace ProspectorInfo.Map
                 }
             }
 
-            foreach (var val in Values)
-                _foundOres.Add(val.Name);
+            AddFoundOres();
         }
 
         /// <summary>
@@ -291,8 +295,7 @@ namespace ProspectorInfo.Map
                 }
             }
 
-            foreach (var val in Values)
-                _foundOres.Add(val.Name);
+            AddFoundOres();
 
             Message = null;
         }

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -127,7 +127,7 @@ namespace ProspectorInfo.Map
                         .HandleWith(OnSetSaveIntervalMinutes)
                     .EndSubCommand()
                     .BeginSubCommand("share")
-                        .WithDescription(".pi share - Share your prospecting data in the cat")
+                        .WithDescription(".pi share - Share your prospecting data in the chat")
                         .HandleWith(OnShare)
                     .EndSubCommand();
 

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -61,9 +61,7 @@ namespace ProspectorInfo.Map
                 };
 
                 // Save data when leaving and periodically.
-                _clientApi.Event.LeaveWorld += () => {
-                    SaveProspectingData();
-                };
+                _clientApi.Event.LeaveWorld += SaveProspectingData;
                 _clientApi.World.RegisterGameTickListener((_) => SaveProspectingData(), 
                         (int) TimeSpan.FromMinutes(_config.SaveIntervalMinutes).TotalMilliseconds);
 

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -179,6 +179,7 @@ namespace ProspectorInfo.Map
                     _prospectInfos[info.ChunkCoordinates] = info;
                     var newComponent = new ProspectorOverlayMapComponent(_clientApi, info.ChunkCoordinates, info.GetMessage(), _colorTextures[(int)GetRelativeDensity(info)]);
                     _components[info.ChunkCoordinates] = newComponent;
+                    info.AddFoundOres();
                 }
                 _prospectInfos.HasChanged = true;
             }

--- a/src/Map/Utils.cs
+++ b/src/Map/Utils.cs
@@ -23,11 +23,16 @@ namespace ProspectorInfo.Map
         }
     }
 
+    [ProtoBuf.ProtoContract(ImplicitFields = ProtoBuf.ImplicitFields.None)]
     internal struct OreOccurence
     {
+        [ProtoBuf.ProtoMember(1)]
         public readonly string Name;
+        [ProtoBuf.ProtoMember(2)]
         public readonly string PageCode;
+        [ProtoBuf.ProtoMember(3, IsRequired = true)]
         public readonly RelativeDensity RelativeDensity;
+        [ProtoBuf.ProtoMember(4)]
         public readonly double AbsoluteDensity;
 
         [Newtonsoft.Json.JsonConstructor]
@@ -57,9 +62,13 @@ namespace ProspectorInfo.Map
         Default,
         Heatmap
     }
+
+    [ProtoBuf.ProtoContract(ImplicitFields = ProtoBuf.ImplicitFields.None)]
     public struct ChunkCoordinates
     {
+        [ProtoBuf.ProtoMember(1)]
         public int X;
+        [ProtoBuf.ProtoMember(2)]
         public int Z;
 
         public ChunkCoordinates(int x, int z)

--- a/src/ModConfig.cs
+++ b/src/ModConfig.cs
@@ -20,5 +20,6 @@ namespace ProspectorInfo
         public string HeatMapOre { get; set; } = null;
         public bool ShowGui { get; set; } = true;
         public int SaveIntervalMinutes { get; set; } = 1;
+        public bool AcceptChatSharing { get; set; } = false;
     }
 }

--- a/src/Utils/ChatDataSharing.cs
+++ b/src/Utils/ChatDataSharing.cs
@@ -1,0 +1,89 @@
+﻿using ProtoBuf;
+using System;
+using System.IO.Compression;
+using System.IO;
+using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using ProspectorInfo.Map;
+using System.Linq;
+
+namespace ProspectorInfo.Utils
+{
+    internal class ChatDataSharing
+    {
+        private static readonly string CHAT_PREFIX = "ProspectingData;";
+
+        private readonly ICoreClientAPI api;
+        private readonly ProspectorOverlayLayer prospectorOverlayLayer;
+        public ChatDataSharing(ICoreClientAPI api, ProspectorOverlayLayer prospectorOverlayLayer)
+        {
+            this.api = api;
+            this.prospectorOverlayLayer = prospectorOverlayLayer;
+            api.Event.ChatMessage += OnChatMessage;
+        }
+
+        private void OnChatMessage(int groupId, string message, EnumChatType chattype, string data) {
+            /*if(chattype != EnumChatType.OthersMessage) 
+            {
+                return;
+            }*/
+            int startIdx = message.IndexOf(CHAT_PREFIX);
+            if (startIdx == -1)
+                return;
+
+            var result = DeserializeFromBase64<ProspectorMessages>(message.Substring(startIdx + CHAT_PREFIX.Length));
+            if (result != null)
+                prospectorOverlayLayer.AddOrUpdateProspectingData(result.Values.ToArray());
+        }
+
+        public void ShareData(ProspectorMessages messages)
+        {
+            string data = SerializeToBase64<ProspectorMessages>(messages);
+            if (data == null) 
+            {
+                return;
+            }
+            api.SendChatMessage(CHAT_PREFIX + data);
+        }
+
+        private string SerializeToBase64<T>(T data) {
+            byte[] result;
+            try
+            {
+                using (var resultStream = new MemoryStream())
+                {
+                    using (var compressionStream = new DeflateStream(resultStream, CompressionLevel.Fastest))
+                    {
+                        Serializer.Serialize(compressionStream, data);
+                    }
+                    result = resultStream.ToArray();
+                    return Convert.ToBase64String(result);
+                }
+            }
+            catch (Exception ex)
+            {
+                api.Logger.Error("Failed to serialize prospecting data", ex);
+                return null;
+            }
+        }
+
+        private T DeserializeFromBase64<T>(string message) where T : class 
+        {
+            try
+            {
+                using (var resultStream = new MemoryStream(Convert.FromBase64String(message)))
+                {
+                    using (var decompressionStream = new DeflateStream(resultStream, CompressionMode.Decompress))
+                    {
+                        return Serializer.Deserialize<T>(decompressionStream);
+                    }
+                }
+            } 
+            catch (Exception ex)
+            {
+                api.Logger.Error("Failed to deserialize shared prospecting data from chat", ex);
+                return null;
+            }
+        }
+    }
+}

--- a/src/Utils/ChatDataSharing.cs
+++ b/src/Utils/ChatDataSharing.cs
@@ -71,18 +71,18 @@ namespace ProspectorInfo.Utils
         /// <summary>
         /// Little hackery to avoid lag spikes when rendering a single long string without whitespace.
         /// </summary>
-        private static string AddWhitespace(string stringResult, int interval)
+        private static string AddWhitespace(string input, int interval)
         {
             StringBuilder stringBuilder = new StringBuilder();
             int currentPosition = 0;
-            while (currentPosition + interval < stringResult.Length)
+            while (currentPosition + interval < input.Length)
             {
-                stringBuilder.Append(stringResult.Substring(currentPosition, interval)).Append(" ");
+                stringBuilder.Append(input.Substring(currentPosition, interval)).Append(" ");
                 currentPosition += interval;
             }
-            if (currentPosition < stringResult.Length)
+            if (currentPosition < input.Length)
             {
-                stringBuilder.Append(stringResult.Substring(currentPosition));
+                stringBuilder.Append(input.Substring(currentPosition));
             }
             return stringBuilder.ToString();
         }

--- a/src/Utils/ChatDataSharing.cs
+++ b/src/Utils/ChatDataSharing.cs
@@ -36,7 +36,7 @@ namespace ProspectorInfo.Utils
             if (!modConfig.AcceptChatSharing)
             {
                 api.ShowChatMessage("Someone shared prospecting data in chat but you currently don't accept data from the chat.<br/>" +
-                    "Use '.pi aceeptchatsharing true' to accept prospecting data in the future.");
+                    "Use '.pi acceptchatsharing true' to accept prospecting data in the future.");
                 return;
             }
 

--- a/src/Utils/ChatDataSharing.cs
+++ b/src/Utils/ChatDataSharing.cs
@@ -23,10 +23,9 @@ namespace ProspectorInfo.Utils
         }
 
         private void OnChatMessage(int groupId, string message, EnumChatType chattype, string data) {
-            /*if(chattype != EnumChatType.OthersMessage) 
-            {
+            if(chattype != EnumChatType.OthersMessage) 
                 return;
-            }*/
+
             int startIdx = message.IndexOf(CHAT_PREFIX);
             if (startIdx == -1)
                 return;

--- a/src/Utils/ChatDataSharing.cs
+++ b/src/Utils/ChatDataSharing.cs
@@ -51,7 +51,7 @@ namespace ProspectorInfo.Utils
             {
                 using (var resultStream = new MemoryStream())
                 {
-                    using (var compressionStream = new DeflateStream(resultStream, CompressionLevel.Fastest))
+                    using (var compressionStream = new DeflateStream(resultStream, CompressionLevel.Optimal))
                     {
                         Serializer.Serialize(compressionStream, data);
                     }


### PR DESCRIPTION
I had a go at #21. This branch is based on #23. The prospecting data can be shared via `.pi share`. The major downside of course is that we abuse the global chat as a broadcast channel. I also noticed that the client struggles to print the huge base64 encoded string, i.e., the client is unresponsive for a few seconds. This problem seems to persist afterwards when using the chat, which is kind of problematic, because this breaks the chat for everyone. 
A wild guess of mine is that the text renderer struggles because it tries to apply word wrapping but the string has no whitespace.

Edit: When adding regular whitespace to the base64 string, the lag spikes no longer occur.