### PR TITLE
Fix the parsing of the propick reading header

### DIFF
--- a/src/Map/ProspectInfo.cs
+++ b/src/Map/ProspectInfo.cs
@@ -34,18 +34,22 @@ namespace ProspectorInfo.Map
         }
         private static readonly Dictionary<string, RelativeDensity> _translatedDensities = GetDensityMappingForLang(Lang.CurrentLocale);
 
-        
+        private static Regex SanitizeRegex(string str) {
+            return new Regex(
+                str.Replace("/", "\\/")
+                   .Replace("(", "\\(")
+                   .Replace(")", "\\)")
+                   .Replace("[", "(")
+                   .Replace("]", ")"),
+                RegexOptions.Compiled);
+        }
 
         private static readonly Regex _cleanupRegex = new Regex("<.*?>", RegexOptions.Compiled);
-        private static readonly Regex _headerParsingRegex = new Regex(Lang.Get("propick-reading-title", ".*?"), RegexOptions.Compiled);
-        private static readonly Regex _readingParsingRegex = new Regex(
+        private static readonly Regex _headerParsingRegex = SanitizeRegex(
+            Lang.Get("propick-reading-title", ".*?")
+        );
+        private static readonly Regex _readingParsingRegex = SanitizeRegex(
             Lang.Get("propick-reading", "[?<relativeDensity>.*?]", "[?<pageCode>.*?]", "[?<oreName>.*?]", "[?<absoluteDensity>.*?]")
-                .Replace("/", "\\/")
-                .Replace("(", "\\(")
-                .Replace(")", "\\)")
-                .Replace("[", "(")
-                .Replace("]", ")"), 
-            RegexOptions.Compiled
         );
 
         /// <summary>
@@ -180,6 +184,14 @@ namespace ProspectorInfo.Map
         private static double ParseDoubleInvariant(string value)
         {
             return double.Parse(value.Replace(",", "."), CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Determines if <paramref name="message"/> is a prospecting info message.
+        /// </summary>
+        /// <param name="message">The prospecting string received from the server</param>
+        public static bool IsHeaderMatch(string message) {
+            return _headerParsingRegex.IsMatch(message);
         }
 
         /// <summary>

--- a/src/Map/ProspectorOverlayLayer.cs
+++ b/src/Map/ProspectorOverlayLayer.cs
@@ -18,7 +18,6 @@ namespace ProspectorInfo.Map
     internal class ProspectorOverlayLayer : MapLayer
     {
         private const string Filename = ProspectorInfoModSystem.DATAFILE;
-        private readonly Regex _headerParsingRegex;
         private readonly ProspectorMessages _prospectInfos;
         private readonly int _chunksize;
         private readonly ICoreClientAPI _clientApi;
@@ -40,7 +39,6 @@ namespace ProspectorInfo.Map
             _worldMapManager = mapSink;
             _chunksize = api.World.BlockAccessor.ChunkSize;
             _prospectInfos = LoadProspectingData();
-            _headerParsingRegex = new Regex(Lang.Get("propick-reading-title", ".*?"), RegexOptions.Compiled);
 
             var modSystem = api.ModLoader.GetModSystem<ProspectorInfoModSystem>();
             _config = modSystem.Config;
@@ -375,7 +373,7 @@ namespace ProspectorInfo.Map
                 return;
 
             var pos = _clientApi.World.Player.WorldData.CurrentGameMode == EnumGameMode.Creative ? blocksSinceLastSuccessList.LastOrDefault()?.Position : blocksSinceLastSuccessList.ElementAtOrDefault(blocksSinceLastSuccessList.Count - 2 - 1)?.Position;
-            if (pos == null || groupId != GlobalConstants.InfoLogChatGroup || !_headerParsingRegex.IsMatch(message))
+            if (pos == null || groupId != GlobalConstants.InfoLogChatGroup || !ProspectInfo.IsHeaderMatch(message))
                 return;
 
             var posX = pos.X / _chunksize;


### PR DESCRIPTION
1.18.2-rc.2 changed propick-reading-title to include parenthesis. So the string has to be sanitized before using it as a regex.

Fixes #32 