### PR TITLE
Add CI build for mod for PRs, commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Build Mod
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    # Restore the application to populate the obj folder with RuntimeIdentifiers
+    - name: Restore the application
+      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=Release
+
+    # Restore the application to populate the obj folder with RuntimeIdentifiers
+    - name: Restore the application
+      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=Release
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: MSIX Package
+        path: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         Invoke-WebRequest -Uri $uri -Out $filename
         $vsdir = $(mkdir VintageStory)
         cd VintageStory
-        tar -zxvf "..\$filename" ./Lib ./Mods
+        tar -zxvf "..\$filename" Lib/ Mods/ VintagestoryAPI.dll
         Add-Content -Path $Env:GITHUB_ENV -Value "VINTAGE_STORY=${vsdir.FullPath}"
       shell: pwsh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build Mod
+name: Build VsProspectorInfo
 
 on:
   push:
@@ -32,7 +32,7 @@ jobs:
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.3.1
 
-    - name: Restore Mod
+    - name: Restore Mod Dependencies
       run: msbuild /t:Restore /p:Configuration=Release
 
     - name: Build Mod
@@ -42,7 +42,7 @@ jobs:
 
     - name: Finalize Artifact
       run: |
-        $mod_name = $(Get-Content .\modinfo.json | jq -r .version)
+        $mod_name = $(Get-Content .\modinfo.json | jq -r .name)
         $mod_version = $(Get-Content .\modinfo.json | jq -r .version)
         Add-Content -Path $Env:GITHUB_ENV -Value "ARTIFACT_NAME=${mod_name}-${mod_version}"
         Remove-Item ./bin/Release/net461/VintagestoryAPI.dll  # not sure why this makes it through the filter?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,12 @@ jobs:
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
 
-    # Restore the application to populate the obj folder with RuntimeIdentifiers
-    - name: Restore the application
-      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=Release
-
-    # Restore the application to populate the obj folder with RuntimeIdentifiers
-    - name: Restore the application
-      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=Release
-
+    - name: Restore
+      run: msbuild /t:Restore /p:Configuration=Release
+    - name: Build
+      run: msbuild /t:Build /p:Configuration=Release
     - name: Upload build artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: MSIX Package
+        name: Mod
         path: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+
     - name: Setup Build Dependencies
       run: |
         $version = $(Get-Content .\modinfo.json | jq -r .dependencies.game)
@@ -27,6 +28,9 @@ jobs:
         tar -zxvf "..\$filename" ./Lib ./Mods
         Add-Content -Path $Env:GITHUB_ENV -Value "VINTAGE_STORY=${vsdir.FullPath}"
       shell: pwsh
+
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Restore Mod
       run: msbuild /t:Restore /p:Configuration=Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: Build Mod
 
 on:
-  workflow_dispatch:
   push:
     branches: [ "master" ]
   pull_request:
@@ -19,9 +18,9 @@ jobs:
 
     - name: Setup Build Dependencies
       run: |
-        $version = $(Get-Content .\modinfo.json | jq -r .dependencies.game)
-        $filename = "vs_server_${version}.tar.gz"
-        $folder = if ($version -like "*-rc*") { "unstable" } else { "stable" }
+        $vs_version = $(Get-Content .\modinfo.json | jq -r .dependencies.game)
+        $filename = "vs_server_${vs_version}.tar.gz"
+        $folder = if ($vs_version -like "*-rc*") { "unstable" } else { "stable" }
         $uri = "https://cdn.vintagestory.at/gamefiles/${folder}/${filename}"
         Invoke-WebRequest -Uri $uri -Out $filename
         $vsdir = $(mkdir VintageStory)
@@ -31,7 +30,7 @@ jobs:
       shell: pwsh
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.3.1
 
     - name: Restore Mod
       run: msbuild /t:Restore /p:Configuration=Release
@@ -41,12 +40,20 @@ jobs:
       env:
         VINTAGE_STORY: ${{ env.VINTAGE_STORY }}
 
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: Mod
-        path: .
+    - name: Finalize Artifact
+      run: |
+        $mod_name = $(Get-Content .\modinfo.json | jq -r .version)
+        $mod_version = $(Get-Content .\modinfo.json | jq -r .version)
+        Add-Content -Path $Env:GITHUB_ENV -Value "ARTIFACT_NAME=${mod_name}-${mod_version}"
+      shell: pwsh
 
     - name: Setup tmate session
-      if: ${{ failure() }}
       uses: mxschmitt/action-tmate@v3
+
+    - name: Upload Mod Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ./bin/Release/net461/
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,60 +15,26 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-
-    - name: Checkout VSApi
-      uses: actions/checkout@v3
-      with:
-        repository: anegostudios/vsapi
-        path: vsapi
-        fetch-depth: 0
-
-    - name: Checkout VSSurvivalMod
-      uses: actions/checkout@v3
-      with:
-        repository: anegostudios/vssurvivalmod
-        path: vssurvivalmod
-        fetch-depth: 0
-    
-    - name: Checkout VSCreativeMod
-      uses: actions/checkout@v3
-      with:
-        repository: anegostudios/vscreativemod
-        path: vscreativemod
-        fetch-depth: 0
-    
-    - name: Checkout VSEssentialsMod
-      uses: actions/checkout@v3
-      with:
-        repository: anegostudios/vsessentialsmod
-        path: vsessentialsmod
-        fetch-depth: 0
-
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
-
-    - name: Restore Dependencies
+    - name: Setup Build Dependencies
       run: |
-        Invoke-WebRequest -Uri "https://download.visualstudio.microsoft.com/download/pr/33a48e6c-c0d1-4321-946b-042b92bad691/a9a88bd451286ab9ea015ecc2208d725/ndp461-devpack-kb3105179-enu.exe" -Out "ndp461-devpack-kb3105179-enu.exe"
-        .\ndp461-devpack-kb3105179-enu.exe /q
-        msbuild vsapi/VintagestoryAPI.csproj /t:Restore
-        msbuild vssurvivalmod/VSSurvivalMod.csproj /t:Restore
-        msbuild vscreativemod/VSCreativeMod.csproj /t:Restore
-        msbuild vsessentialsmod/VSEssentialsMod.csproj /t:Restore
-
-    - name: Build Dependencies
-      run: |
-        msbuild vsapi/VintagestoryAPI.csproj /t:Build
-        msbuild vssurvivalmod/VSSurvivalMod.csproj /t:Build
-        msbuild vscreativemod/VSCreativeMod.csproj /t:Build
-        msbuild vsessentialsmod/VSEssentialsMod.csproj /t:Restore
+        $version = $(Get-Content .\modinfo.json | jq -r .dependencies.game)
+        $filename = "vs_server_${version}.tar.gz"
+        $folder = if ($version -like "*-rc*") { "unstable" } else { "stable" }
+        $uri = "https://cdn.vintagestory.at/gamefiles/${folder}/${filename}"
+        Invoke-WebRequest -Uri $uri -Out $filename
+        $vsdir = $(mkdir VintageStory)
+        cd VintageStory
+        tar -zxvf ..\vs_server_1.18.2-rc.4.tar.gz ./Lib ./Mods
+        Add-Content -Path $Env:GITHUB_ENV -Value "VINTAGE_STORY=${vsdir.FullPath}"
+      shell: pwsh
 
     - name: Restore Mod
       run: msbuild /t:Restore /p:Configuration=Release
 
     - name: Build Mod
       run: msbuild /t:Build /p:Configuration=Release
-      shell: pwsh
+      env:
+        VINTAGE_STORY: ${{ env.VINTAGE_STORY }}
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,8 @@ jobs:
         $mod_name = $(Get-Content .\modinfo.json | jq -r .version)
         $mod_version = $(Get-Content .\modinfo.json | jq -r .version)
         Add-Content -Path $Env:GITHUB_ENV -Value "ARTIFACT_NAME=${mod_name}-${mod_version}"
+        Remove-Item ./bin/Release/net461/VintagestoryAPI.dll  # not sure why this makes it through the filter?
       shell: pwsh
-
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
 
     - name: Upload Mod Artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Build Mod
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "master" ]
   pull_request:
@@ -48,6 +49,8 @@ jobs:
 
     - name: Restore Dependencies
       run: |
+        Invoke-WebRequest -Uri "https://download.visualstudio.microsoft.com/download/pr/33a48e6c-c0d1-4321-946b-042b92bad691/a9a88bd451286ab9ea015ecc2208d725/ndp461-devpack-kb3105179-enu.exe" -Out "ndp461-devpack-kb3105179-enu.exe"
+        .\ndp461-devpack-kb3105179-enu.exe /q
         msbuild vsapi/VintagestoryAPI.csproj /t:Restore
         msbuild vssurvivalmod/VSSurvivalMod.csproj /t:Restore
         msbuild vscreativemod/VSCreativeMod.csproj /t:Restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         Invoke-WebRequest -Uri $uri -Out $filename
         $vsdir = $(mkdir VintageStory)
         cd VintageStory
-        tar -zxvf ..\vs_server_1.18.2-rc.4.tar.gz ./Lib ./Mods
+        tar -zxvf "..\$filename" ./Lib ./Mods
         Add-Content -Path $Env:GITHUB_ENV -Value "VINTAGE_STORY=${vsdir.FullPath}"
       shell: pwsh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,64 @@ jobs:
       with:
         fetch-depth: 0
 
-    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+    - name: Checkout VSApi
+      uses: actions/checkout@v3
+      with:
+        repository: anegostudios/vsapi
+        path: vsapi
+        fetch-depth: 0
+
+    - name: Checkout VSSurvivalMod
+      uses: actions/checkout@v3
+      with:
+        repository: anegostudios/vssurvivalmod
+        path: vssurvivalmod
+        fetch-depth: 0
+    
+    - name: Checkout VSCreativeMod
+      uses: actions/checkout@v3
+      with:
+        repository: anegostudios/vscreativemod
+        path: vscreativemod
+        fetch-depth: 0
+    
+    - name: Checkout VSEssentialsMod
+      uses: actions/checkout@v3
+      with:
+        repository: anegostudios/vsessentialsmod
+        path: vsessentialsmod
+        fetch-depth: 0
+
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
 
-    - name: Restore
+    - name: Restore Dependencies
+      run: |
+        msbuild vsapi/VintagestoryAPI.csproj /t:Restore
+        msbuild vssurvivalmod/VSSurvivalMod.csproj /t:Restore
+        msbuild vscreativemod/VSCreativeMod.csproj /t:Restore
+        msbuild vsessentialsmod/VSEssentialsMod.csproj /t:Restore
+
+    - name: Build Dependencies
+      run: |
+        msbuild vsapi/VintagestoryAPI.csproj /t:Build
+        msbuild vssurvivalmod/VSSurvivalMod.csproj /t:Build
+        msbuild vscreativemod/VSCreativeMod.csproj /t:Build
+        msbuild vsessentialsmod/VSEssentialsMod.csproj /t:Restore
+
+    - name: Restore Mod
       run: msbuild /t:Restore /p:Configuration=Release
-    - name: Build
+
+    - name: Build Mod
       run: msbuild /t:Build /p:Configuration=Release
+      shell: pwsh
+
     - name: Upload build artifacts
       uses: actions/upload-artifact@v3
       with:
         name: Mod
         path: .
+
+    - name: Setup tmate session
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        submodules: true  # fetch Foundation
 
     - name: Setup Build Dependencies
       run: |

--- a/ProspectorInfo.csproj
+++ b/ProspectorInfo.csproj
@@ -31,7 +31,7 @@
       <HintPath>$(VINTAGE_STORY)\Lib\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Harmony">
+    <Reference Include="0Harmony">
       <HintPath>$(VINTAGE_STORY)\Lib\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>


### PR DESCRIPTION
This adds a workflow for PRs and pushes to master that will build the module zip and put it in the artifacts for the workflow:

https://github.com/Homicydal/VsProspectorInfo/actions/runs/4968605980

I'm not sure why I had to change the reference name from `Harmony` to `0Harmony` in my version but it works locally for folks; I haven't tested locally myself but only in CI. I do note that when I dotpeek the .dll released with the module that it doesn't directly take a dependency on `0Harmony.dll` so this shouldn't affect output. It might be worth checking development and builds locally for this PR before merging to make sure it doesn't disrupt existing development workflows.